### PR TITLE
update:controller_contractor_create

### DIFF
--- a/app/controllers/contractors_controller.rb
+++ b/app/controllers/contractors_controller.rb
@@ -9,7 +9,7 @@ class ContractorsController < ApplicationController
   end
 
   def create
-    @contractor = current_parking_manager.contractor.build(contractor_params)
+    @contractor = current_parking_manager.contractors.build(contractor_params)
     authorize @contractor
 
     if @contractor.save


### PR DESCRIPTION
# 概要
新規で契約者を作成する際、何も記載していない状態で作成時、エラーが発生

# 内容
controller_contractorのcreateアクションの変数が間違っていたためエラーが発生していた