### PR TITLE
fix:parking_manager_logout_pathの見直し

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -44,10 +44,8 @@ class ApplicationController < ActionController::Base
   def after_sign_out_path_for(resource_or_scope)
     if resource_or_scope == :admin
       new_admin_session_path
-    elsif resource_or_scope == :parking_manager
-      new_parking_manager_session_path
     else
-      root_path
+      new_parking_manager_session_path
     end
   end
 


### PR DESCRIPTION
### 概要
Render側で一般ユーザーがログアウトできない問題を修正

### 内容
アプリ管理者を導入したことにより、一般ユーザーがログアウト時、管理者側のログアウトへ遷移しようとしていたためステータス：500が発生していました。

パスの動線を再度設定し直しそれぞれのログイン画面へ遷移するようにしました。