### PR TITLE
update:device名をそれぞれ地域、名前に分けて単一責任の設計に変更

### DIFF
--- a/app/decorators/device_decorator.rb
+++ b/app/decorators/device_decorator.rb
@@ -6,11 +6,6 @@ class DeviceDecorator < Draper::Decorator
   end
 
   def friendly_name(remote_ip)
-    location = Geocoder.search(remote_ip).first
-    city_info = location&.city.present? ? "#{location.city}付近の" : "不明な場所の"
-
-    device_label = Device.set_name_by_user_agent(device.user_agent, nil)
-
-    "#{city_info}#{device_label}"
+    Device.generate_friendly_name(object.user_agent, remote_ip)
   end
 end

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -15,14 +15,21 @@ class Device < ApplicationRecord
     /Macintosh/i => "Mac(パソコン)"
   }.freeze
 
-  def self.set_name_by_user_agent(user_agent, ip_address)
-    user_agent_string = user_agent.to_s
-    device_type = DEVICE_TYPES.find { |pattern, _name| user_agent_string.match?(pattern) }&.last || "不明な端末"
-
+  def self.get_city_name(ip_address)
     location = Geocoder.search(ip_address).first
-    city_info = location&.city.present? ? "#{location.city}付近の" : "不明な場所の"
+    location&.city.present? ? "#{location.city}付近の" : "不明な場所の"
+  end
 
-    "#{city_info}#{device_type}"
+  def self.get_type_by_user_agent(user_agent)
+    user_agent_string = user_agent.to_s
+    DEVICE_TYPES.find { |pattern, _name| user_agent_string.match?(pattern) }&.last || "不明な端末"
+  end
+
+  def self.generate_friendly_name(user_agent, ip_address)
+    city = get_city_name(ip_address)
+    device_type = get_type_by_user_agent(user_agent)
+
+    "#{city}#{device_type}"
   end
 
   # 期間内かつ承認済みかどうかを確認


### PR DESCRIPTION
Renderデプロイ時、変数を少なかったためエラーが発生していた。

一つのメソッドに多機能を入れる設計から単一責任の法則に則り設計を見直しました。
