### PR TITLE
Fix auth card.html

### DIFF
--- a/app/views/parking_managers/devices/verified_success.html.erb
+++ b/app/views/parking_managers/devices/verified_success.html.erb
@@ -1,4 +1,4 @@
-<%= render layout: 'parking_managers/shared/auth_card', locals: { title: "端末の登録が完了しました" } do %>
+<%= render layout: 'parking_managers/shared/auth_card', locals: { title: "端末の登録が完了しました", layout: 'card' } do %>
 
   <p class="text-sm text-gray-600">
   この端末「<span class="font-semibold text-gray-900"><%= @device.name %></span>」を信頼済みとして登録しました。

--- a/app/views/parking_managers/devices/wait_verification.html.erb
+++ b/app/views/parking_managers/devices/wait_verification.html.erb
@@ -1,4 +1,4 @@
-<%= render layout: 'parking_managers/shared/auth_card', locals: { title: "メールを確認してください。" } do %>
+<%= render layout: 'parking_managers/shared/auth_card', locals: { title: "メールを確認してください。", layout: 'card' }  do %>
 
   <p class="text-gray-600 mb-8">
   新しい端末（<%= @device.name %>）を検知しました。<br>

--- a/app/views/parking_managers/shared/_auth_card.html.erb
+++ b/app/views/parking_managers/shared/_auth_card.html.erb
@@ -1,29 +1,22 @@
-<% if parking_manager_signed_in? %>
-  <div class="container mx-auto px-4 py-10 max-w-2xl">
+<% layout_type = local_assigns[:layout] || (parking_manager_signed_in? ? 'full' : 'card') %>
 
+<% if layout_type == 'full' %>
+  <div class="container mx-auto px-4 py-10 max-w-2xl">
     <% if local_assigns[:title] %>
-      <h1 class="text-2xl font-black text-gray-900 mb-4 px-2">
-        <%= title %>
-      </h1>
+      <h1 class="text-2xl font-black text-gray-900 mb-4 px-2"><%= title %></h1>
     <% end %>
     <div class="sm:p-6">
       <%= yield %>
     </div>
   </div>
 
-<% else %>
-
+<% elsif layout_type == 'card' %>
   <div class="flex justify-center items-start bg-gray-100 py-12 px-4 sm:px-6 lg:px-8">
     <div class="w-full max-w-md p-8 space-y-6 bg-white rounded-xl shadow-lg h-fit">
-
       <% if local_assigns[:title] %>
-      <h2 class="text-3xl font-extrabold text-center text-gray-900">
-        <%= title %>
-      </h2>
-    <% end %>
-
-    <%= yield %>
-
+        <h2 class="text-3xl font-extrabold text-center text-gray-900"><%= title %></h2>
+      <% end %>
+      <%= yield %>
     </div>
   </div>
 <% end %>


### PR DESCRIPTION
# 概要
_auth_card.htmlデザインパターンの修正

# 内容
独自のセッション管理の端末未登録時のデザインではログインセッションを保持しつつ、ログアウト状態のように見せる設計のため、現在の設計ではカバーできていなかったので修正しました。

_auth_card.html.erbに新たにcard変数と定義して待機ページでもlayout: 'card'を追加することでカード形式でデザインを見せることができます。