### PR TITLE
update:ログイン時のヘッダーデザインを修正

### DIFF
--- a/app/views/shared/_header_signed_in.html.erb
+++ b/app/views/shared/_header_signed_in.html.erb
@@ -8,7 +8,7 @@
 
   <div class="flex items-center gap-1 md:gap-3">
 
-    <div class="relative group hidden lg:block mr-2">
+    <div class="relative group mr-2">
       <span class="material-symbols-outlined absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 text-xl">search</span>
       <input type="text"
              placeholder="検索..."

--- a/app/views/shared/_header_signed_in.html.erb
+++ b/app/views/shared/_header_signed_in.html.erb
@@ -9,35 +9,43 @@
   <div class="flex items-center gap-1 md:gap-3">
 
     <div class="relative group hidden lg:block mr-2">
+      <span class="material-symbols-outlined absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 text-xl">search</span>
       <input type="text"
              placeholder="検索..."
-             class="bg-slate-100 border-none rounded-full py-1.5 px-10 text-sm focus:ring-2 focus:ring-sky-500 w-40 xl:w-60 transition-all">
+             class="bg-slate-100 border-none rounded-full py-1.5 pl-10 pr-4 text-sm focus:ring-2 focus:ring-sky-500 w-40 xl:w-60 transition-all placeholder:text-slate-400">
     </div>
 
     <button class="p-2 text-slate-500 hover:bg-sky-50 rounded-full transition-colors relative">
-      <span class="material-symbols-outlined">notifications</span>
+      <span class="material-symbols-outlined" style="font-variation-settings: 'FILL' 0, 'wght' 400;">notifications</span>
       <span class="absolute top-2.5 right-2.5 w-2 h-2 bg-red-500 rounded-full border-2 border-white"></span>
     </button>
 
     <%= link_to settings_path, class: "p-2 text-slate-500 hover:bg-sky-50 rounded-full transition-colors" do %>
-      <span class="material-symbols-outlined">設定</span>
+      <span class="material-symbols-outlined" style="font-variation-settings: 'FILL' 0, 'wght' 400;">settings</span>
     <% end %>
 
-    <%# モバイル用メニューボタン (一番右に配置) %>
     <button class="md:hidden p-2 ml-1 text-slate-600 hover:bg-sky-50 rounded-lg transition-colors" id="mobile-menu-button">
-      <span class="material-symbols-outlined">メニュー</span>
+      <span class="material-symbols-outlined">menu</span>
     </button>
   </div>
 
-  <%# --- モバイル用ドロップダウンメニュー --- %>
   <div class="hidden absolute top-16 left-0 right-0 bg-white border-b border-slate-100 shadow-xl md:hidden" id="mobile-menu">
     <div class="p-4 space-y-1">
-      <%= link_to "ダッシュボード", my_dashboard_root_path, class: "flex items-center gap-3 px-4 py-3 rounded-lg text-slate-700 hover:bg-sky-50" %>
-      <%= link_to "駐車場管理", parking_lots_path, class: "flex items-center gap-3 px-4 py-3 rounded-lg text-slate-700 hover:bg-sky-50" %>
-      <%= link_to "契約者管理", contractors_path, class: "flex items-center gap-3 px-4 py-3 rounded-lg text-slate-700 hover:bg-sky-50" %>
+      <%= link_to my_dashboard_root_path, class: "flex items-center gap-3 px-4 py-3 rounded-lg text-slate-700 hover:bg-sky-50 font-semibold" do %>
+        <span class="material-symbols-outlined text-slate-400">dashboard</span>
+        ダッシュボード
+      <% end %>
+      <%= link_to parking_lots_path, class: "flex items-center gap-3 px-4 py-3 rounded-lg text-slate-700 hover:bg-sky-50 font-semibold" do %>
+        <span class="material-symbols-outlined text-slate-400">local_parking</span>
+        駐車場管理
+      <% end %>
+      <%= link_to contractors_path, class: "flex items-center gap-3 px-4 py-3 rounded-lg text-slate-700 hover:bg-sky-50 font-semibold" do %>
+        <span class="material-symbols-outlined text-slate-400">group</span>
+        契約者管理
+      <% end %>
       <hr class="my-2 border-slate-100">
-      <%= link_to "お問い合わせ", new_contact_path, class: "flex items-center gap-3 px-4 py-3 rounded-lg text-slate-700 hover:bg-sky-50" %>
-      <%= button_to "ログアウト", destroy_parking_manager_session_path, method: :delete, class: "w-full text-left flex items-center gap-3 px-4 py-3 rounded-lg text-red-500 hover:bg-red-50" %>
+      <%= link_to "お問い合わせ", new_contact_path, class: "flex items-center gap-3 px-4 py-3 rounded-lg text-slate-700 hover:bg-sky-50 font-semibold" %>
+      <%= button_to "ログアウト", destroy_parking_manager_session_path, method: :delete, class: "w-full text-left flex items-center gap-3 px-4 py-3 rounded-lg text-red-500 hover:bg-red-50 font-semibold" %>
     </div>
   </div>
 </header>


### PR DESCRIPTION
# 概要
ログイン時のヘッダーデザインを修正

# 内容
ログイン時の時のヘッダーにあるボタンデザインと検索デザインを修正しました。
スマホ、タブレットサイズでも検索欄を表示するよう修正しました。

PC, phone: 設定を⚙️アイコンに変更、検索欄に🔍を追加しました。
phone: メニューにハンバーガーバーに変更