### PR TITLE
Fix setting title

### DIFF
--- a/app/views/parking_managers/settings/index.html.erb
+++ b/app/views/parking_managers/settings/index.html.erb
@@ -1,13 +1,18 @@
 <div class="container mx-auto px-4 py-10 max-w-2xl">
   <h1 class="text-2xl font-black text-gray-900 mb-8 px-2">
-    <%= t(".title") %>
+    <%= partial_name == 'account_setting' ? 'アカウント設定' : '設定' %>
   </h1>
 
   <div class="bg-white shadow-sm border border-gray-100 rounded-3xl overflow-hidden">
     <%= render partial_name %>
   </div>
 
-  <p class="text-center text-gray-400 text-xs mt-10">
-    v1.0.0 &copy; 2026 tukigime-parking.com
-  </p>
+  <% if partial_name == 'account_setting' %>
+    <div class="mt-6 px-2">
+      <%= link_to settings_path, class: "text-sm text-gray-500 hover:text-sky-600 flex items-center gap-1" do %>
+        <span class="material-symbols-outlined text-sm">arrow_back</span>
+        設定トップに戻る
+      <% end %>
+    </div>
+  <% end %>
 </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -5,10 +5,6 @@ ja:
         edit:
           password: "新しいパスワード"
           password_confirmation: "パスワード(確認用)"
-    settings:
-      index:
-        title: "設定"
-        title: "アカウント設定"
   site:
     name: "tukigime-parking.com"
     support_email: "support@tukigime-parking.com"


### PR DESCRIPTION
# 概要
アプリ設定のデザイン修正

# 内容
アプリ設定画面のタイトルが切り替えることができなかったので修正しました。
アカウント設定画面で新たに’設定トップへ戻る’を追加しました。