### PR TITLE
Fix account error

### DIFF
--- a/app/controllers/parking_managers/email_confirmations_controller.rb
+++ b/app/controllers/parking_managers/email_confirmations_controller.rb
@@ -4,18 +4,24 @@ class ParkingManagers::EmailConfirmationsController < ApplicationController
   end
 
   def create
-    email = params[:email_confirmation][:email]
+    email = email_confirmation_params[:email]
 
-    if ParkingManager.exists?(email: email)
+    if ParkingManager.exists?(email_confirmation_params)
       Rails.logger.info "⚠️ [SKIP] Email already exists: #{email}はすでに登録済みです"
       redirect_to new_parking_manager_session_path, success: "登録用メールが送信されました。"
     else
       Rails.logger.info "📧 [SEND] Preparing to send email to: #{email}の確認レコードを作成します"
 
-      confirmation = EmailConfirmation.create!(email: email)
+      confirmation = EmailConfirmation.create!(email_confirmation_params)
       ParkingManagers::RegistrationMailer.confirmation_link(confirmation).deliver_later
 
       redirect_to new_parking_manager_session_path, success: "登録用メールが送信されました。"
     end
+  end
+
+  private
+
+  def email_confirmation_params
+    params.require(:email_confirmation).permit(:email)
   end
 end

--- a/app/controllers/parking_managers/registrations_controller.rb
+++ b/app/controllers/parking_managers/registrations_controller.rb
@@ -10,7 +10,7 @@ class ParkingManagers::RegistrationsController < Devise::RegistrationsController
     token = params[:token]
     confirmation = EmailConfirmation.find_by(token: token)
 
-    if confirmation && confirmation.expires_at > Time.current
+    if confirmation.active?
       build_resource({ email: confirmation.email })
       yield resource if block_given?
       respond_with resource

--- a/app/models/concerns/token_confirmable.rb
+++ b/app/models/concerns/token_confirmable.rb
@@ -25,7 +25,7 @@ module TokenConfirmable
   private
 
   def generate_token
-    self.token =SecureRandom.urlsafe_base64(32)
+    self.token = SecureRandom.urlsafe_base64(32)
     self.confirmation_sent_at = Time.current
   end
 end

--- a/db/migrate/20260429043742_drop_archived_inquiries.rb
+++ b/db/migrate/20260429043742_drop_archived_inquiries.rb
@@ -1,0 +1,9 @@
+class DropArchivedInquiries < ActiveRecord::Migration[8.1]
+  def change
+    if table_exists?(:archived_inquiries)
+      drop_table :archived_inquiries
+    else
+      puts "⚠️ table 'archived_inquiries' does not exist. Skipping..."
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_22_084055) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_29_043742) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"


### PR DESCRIPTION
# 概要
アカウント作成時エラーを修正

# 内容
アカウント作成時メールを送信後、メールのリンクからブラウザでアカウント作成時エラーが発生していたのを修正しました。
原因はトークンの有効期間の設定メソッドが間違っていたことが原因でした。