### PR TITLE
update:契約者作成ボタンの表示が間違っていたので修正

### DIFF
--- a/app/views/contractors/_form.html.erb
+++ b/app/views/contractors/_form.html.erb
@@ -81,7 +81,7 @@
 
   <%# 4. 送信ボタン %>
   <div class="actions pt-4">
-    <%= f.submit (contractor.new_record? ? "駐車場スペース作成    " : "更新する"),
+    <%= f.submit (contractor.new_record? ? "契約者作成" : "更新する"),
       class: "auth-submit" %>
   </div>
 <% end %>


### PR DESCRIPTION
## 概要
contractor_newの作成ボタンの表示間違いを修正

## 内容
契約者の作成ページの契約者作成ボタンの表示が　”駐車スペース作成”　になっていたので修正しました。