### PR TITLE
Fix/statistic data query

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -28,7 +28,7 @@ class DashboardsController < ApplicationController
     # 総スペース数
     @total_capacity       = total_status[:total_capacity]
     # 稼働率
-    @occupancy_rate       = total_status[:occupancy_rate].positive? ?
+    @occupancy_rate       = total_status[:total_capacity].positive? ?
       (total_status[:contracted_count].to_f /
        total_status[:total_capacity] * 100).round(1) : 0
     # 月間収益

--- a/app/services/parking_statistics_service.rb
+++ b/app/services/parking_statistics_service.rb
@@ -18,18 +18,20 @@ class  ParkingStatisticsService
   end
 
   def monthly_occupancy_rate
-    today = Date.today
-    start_period = 5.months.ago.to_date
     total = parking_spaces.count
 
-    monthly_contracts = ContractParkingSpace
-      .joins(:parking_space)
+    (0..5).reverse_each.each_with_object({}) do |i, result|
+      target = i.months.ago.beginning_of_month.to_date
+
+    count = ContractParkingSpace
       .where(parking_manager_id: @parking_manager.id)
-      .group_by_month(:start_date, range: start_period..today.end_of_day)
+      .where("start_date <= ?", target.end_of_month)
+      .where("end_date >= ?", target.beginning_of_month)
+      .where("start_date != end_date")
       .count
 
-    monthly_contracts.transform_values do |count|
-      total.positive? ? (count.to_f / total * 100).round(1) : 0
+    result[target] = total.positive? ?
+      (count.to_f / total * 100).round(1) : 0
     end
   end
 end


### PR DESCRIPTION
## 概要
ダッシュボードの稼働率棒グラフのビジネスロジックを修正

## 内容
前の仕様では、今月の値と過去の値が足して計算されていなかったので統計に矛盾が発生していました。
原因は稼働率の棒グラフの表示のクエリが間違っていたので修正し、即日契約終了時でも対応できる仕様に変更しました。