### PR TITLE
Feature/rspec parking manager create

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,6 +81,7 @@ group :development, :test do
   gem "binding_of_caller"
 
   gem "rspec-rails", "~> 8.0.0"
+  gem "factory_bot_rails"
 
   # デバックツール
   gem "pry-byebug"

--- a/Gemfile
+++ b/Gemfile
@@ -81,7 +81,12 @@ group :development, :test do
   gem "binding_of_caller"
 
   gem "rspec-rails", "~> 8.0.0"
+
+  # テストデータのセットアップサポート
   gem "factory_bot_rails"
+
+  # ダミーデータ作成
+  gem "faker"
 
   # デバックツール
   gem "pry-byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,6 +157,8 @@ GEM
     factory_bot_rails (6.5.1)
       factory_bot (~> 6.5)
       railties (>= 6.1.0)
+    faker (3.8.0)
+      i18n (>= 1.8.11, < 2)
     ffi (1.17.4-aarch64-linux-gnu)
     ffi (1.17.4-aarch64-linux-musl)
     ffi (1.17.4-arm-linux-gnu)
@@ -489,6 +491,7 @@ DEPENDENCIES
   draper
   enum_help
   factory_bot_rails
+  faker
   geocoder
   groupdate
   image_processing (~> 1.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,6 +152,11 @@ GEM
       activesupport (>= 3.0.0)
     erb (6.0.4)
     erubi (1.13.1)
+    factory_bot (6.6.0)
+      activesupport (>= 6.1.0)
+    factory_bot_rails (6.5.1)
+      factory_bot (~> 6.5)
+      railties (>= 6.1.0)
     ffi (1.17.4-aarch64-linux-gnu)
     ffi (1.17.4-aarch64-linux-musl)
     ffi (1.17.4-arm-linux-gnu)
@@ -483,6 +488,7 @@ DEPENDENCIES
   dotenv-rails
   draper
   enum_help
+  factory_bot_rails
   geocoder
   groupdate
   image_processing (~> 1.2)

--- a/spec/models/parking_manager_spec.rb
+++ b/spec/models/parking_manager_spec.rb
@@ -12,32 +12,32 @@ RSpec.describe ParkingManager, type: :model do
 
     # 失敗パターン
     context 'バリデーション失敗' do
-      it 'first_nameが21文字以上の場合' do 
+      it 'first_nameが21文字以上の場合' do
         parking_manager.first_name = 'あ' * 21
         expect(parking_manager).to be_invalid
       end
 
-      it 'first_nameが空欄の場合' do 
+      it 'first_nameが空欄の場合' do
         parking_manager.first_name = nil
         expect(parking_manager).to be_invalid
       end
 
-      it 'last_nameが21文字以上の場合' do 
+      it 'last_nameが21文字以上の場合' do
         parking_manager.last_name = 'あ' * 21
         expect(parking_manager).to be_invalid
       end
 
-      it 'last_nameが空欄の場合' do 
+      it 'last_nameが空欄の場合' do
         parking_manager.last_name = nil
         expect(parking_manager).to be_invalid
       end
 
-      it 'emailが51文字以上だった場合' do 
+      it 'emailが51文字以上だった場合' do
         parking_manager.email = 'あ' * 51
         expect(parking_manager).to be_invalid
       end
 
-      it 'emailが空欄だった場合' do 
+      it 'emailが空欄だった場合' do
         parking_manager.email = nil
         expect(parking_manager).to be_invalid
       end
@@ -54,12 +54,12 @@ RSpec.describe ParkingManager, type: :model do
         expect(parking_manager.errors[:prefecture]).to contain_exactly("を正しく選択してください")
       end
 
-      it 'cityが21文字以上の場合' do 
+      it 'cityが21文字以上の場合' do
         parking_manager.city = 'あ' * 21
         expect(parking_manager).to be_invalid
       end
 
-      it 'cityが空欄の場合' do 
+      it 'cityが空欄の場合' do
         parking_manager.city = nil
         expect(parking_manager).to be_invalid
       end
@@ -69,17 +69,17 @@ RSpec.describe ParkingManager, type: :model do
         expect(parking_manager).to be_invalid
       end
 
-      it 'street_addressが空欄の場合' do 
+      it 'street_addressが空欄の場合' do
         parking_manager.street_address = nil
         expect(parking_manager).to be_invalid
       end
 
-      it 'buildingが56文字以上の場合' do 
+      it 'buildingが56文字以上の場合' do
         parking_manager.building = 'あ' * 56
         expect(parking_manager).to be_invalid
       end
 
-      it 'phone_numberが11文字数以外だった場合' do 
+      it 'phone_numberが11文字数以外だった場合' do
         parking_manager.phone_number = '1' * 10
         expect(parking_manager).to be_invalid
 
@@ -87,23 +87,23 @@ RSpec.describe ParkingManager, type: :model do
         expect(parking_manager).to be_invalid
       end
 
-      it 'phone_numberが数字以外だった場合' do 
+      it 'phone_numberが数字以外だった場合' do
         parking_manager.phone_number = 'あいうえお。、＠％＆＊！'
         expect(parking_manager).to be_invalid
       end
 
-      it 'phone_numberが空欄だった場合' do 
+      it 'phone_numberが空欄だった場合' do
         parking_manager.phone_number = nil
         expect(parking_manager).to be_invalid
       end
 
-      it 'phone_numberが他のユーザーと重複した場合' do 
+      it 'phone_numberが他のユーザーと重複した場合' do
       parking_manager = create(:parking_manager, phone_number: '09012341234')
       parking_manager_1 = build(:parking_manager, phone_number: '09012341234')
       expect(parking_manager_1).to be_invalid
       end
 
-      it 'contact_numberが10文字以上11文字以内でなかった場合' do 
+      it 'contact_numberが10文字以上11文字以内でなかった場合' do
         parking_manager.contact_number = '1' * 9
         expect(parking_manager).to be_invalid
 

--- a/spec/models/parking_manager_spec.rb
+++ b/spec/models/parking_manager_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ParkingManager, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/parking_manager_spec.rb
+++ b/spec/models/parking_manager_spec.rb
@@ -1,5 +1,126 @@
 require 'rails_helper'
 
 RSpec.describe ParkingManager, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  # 成功パターン
+  describe 'create' do
+    let(:parking_manager) { FactoryBot.build(:parking_manager) }
+    context 'バリデーションチェック' do
+      it '設定した全てのバリデーションが機能しているか' do
+        expect(parking_manager).to be_valid
+      end
+    end
+
+    # 失敗パターン
+    context 'バリデーション失敗' do
+      it 'first_nameが21文字以上の場合' do 
+        parking_manager.first_name = 'あ' * 21
+        expect(parking_manager).to be_invalid
+      end
+
+      it 'first_nameが空欄の場合' do 
+        parking_manager.first_name = nil
+        expect(parking_manager).to be_invalid
+      end
+
+      it 'last_nameが21文字以上の場合' do 
+        parking_manager.last_name = 'あ' * 21
+        expect(parking_manager).to be_invalid
+      end
+
+      it 'last_nameが空欄の場合' do 
+        parking_manager.last_name = nil
+        expect(parking_manager).to be_invalid
+      end
+
+      it 'emailが51文字以上だった場合' do 
+        parking_manager.email = 'あ' * 51
+        expect(parking_manager).to be_invalid
+      end
+
+      it 'emailが空欄だった場合' do 
+        parking_manager.email = nil
+        expect(parking_manager).to be_invalid
+      end
+
+      it 'emailが既に登録されている場合' do
+        parking_manager = create(:parking_manager, email: 'user@email.com')
+        parking_manager_1 = build(:parking_manager, email: 'user@email.com')
+        expect(parking_manager_1).to be_invalid
+      end
+
+      it 'prefectureが選択されていない場合' do
+        parking_manager.prefecture = nil
+        expect(parking_manager).to be_invalid
+        expect(parking_manager.errors[:prefecture]).to contain_exactly("を正しく選択してください")
+      end
+
+      it 'cityが21文字以上の場合' do 
+        parking_manager.city = 'あ' * 21
+        expect(parking_manager).to be_invalid
+      end
+
+      it 'cityが空欄の場合' do 
+        parking_manager.city = nil
+        expect(parking_manager).to be_invalid
+      end
+
+      it 'street_addressが51文字以上の場合' do
+        parking_manager.street_address = 'あ' * 51
+        expect(parking_manager).to be_invalid
+      end
+
+      it 'street_addressが空欄の場合' do 
+        parking_manager.street_address = nil
+        expect(parking_manager).to be_invalid
+      end
+
+      it 'buildingが56文字以上の場合' do 
+        parking_manager.building = 'あ' * 56
+        expect(parking_manager).to be_invalid
+      end
+
+      it 'phone_numberが11文字数以外だった場合' do 
+        parking_manager.phone_number = '1' * 10
+        expect(parking_manager).to be_invalid
+
+        parking_manager.phone_number = '1' * 12
+        expect(parking_manager).to be_invalid
+      end
+
+      it 'phone_numberが数字以外だった場合' do 
+        parking_manager.phone_number = 'あいうえお。、＠％＆＊！'
+        expect(parking_manager).to be_invalid
+      end
+
+      it 'phone_numberが空欄だった場合' do 
+        parking_manager.phone_number = nil
+        expect(parking_manager).to be_invalid
+      end
+
+      it 'phone_numberが他のユーザーと重複した場合' do 
+      parking_manager = create(:parking_manager, phone_number: '09012341234')
+      parking_manager_1 = build(:parking_manager, phone_number: '09012341234')
+      expect(parking_manager_1).to be_invalid
+      end
+
+      it 'contact_numberが10文字以上11文字以内でなかった場合' do 
+        parking_manager.contact_number = '1' * 9
+        expect(parking_manager).to be_invalid
+
+        parking_manager.contact_number = '1' * 12
+        expect(parking_manager).to be_invalid
+      end
+
+      it 'contact_numberが数字以外だった場合' do
+        parking_manager.contact_number = 'あいうえお。、＠％-＆＊！'
+        expect(parking_manager).to be_invalid
+      end
+
+      it '利用規約の同意がチェックされていなかった場合' do
+        parking_manager.terms_of_service = false
+        expect(parking_manager).to be_invalid
+        expect(parking_manager.errors[:terms_of_service]).to contain_exactly("に同意してください")
+      end
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -48,6 +48,9 @@ RSpec.configure do |config|
   # You can uncomment this line to turn off ActiveRecord support entirely.
   # config.use_active_record = false
 
+  # FactoryBotを有効
+  config.include FactorBot::Syntax::Methods
+
   # RSpec Rails uses metadata to mix in different behaviours to your tests,
   # for example enabling you to call `get` and `post` in request specs. e.g.:
   #

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -49,7 +49,7 @@ RSpec.configure do |config|
   # config.use_active_record = false
 
   # FactoryBotを有効
-  config.include FactorBot::Syntax::Methods
+  config.include FactoryBot::Syntax::Methods
 
   # RSpec Rails uses metadata to mix in different behaviours to your tests,
   # for example enabling you to call `get` and `post` in request specs. e.g.:

--- a/test/factories/parking_managers.rb
+++ b/test/factories/parking_managers.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :parking_manager do
+    
+  end
+end

--- a/test/factories/parking_managers.rb
+++ b/test/factories/parking_managers.rb
@@ -1,6 +1,5 @@
 FactoryBot.define do
   factory :parking_manager do
-    
     first_name { Faker::Name.first_name }
     last_name { Faker::Name.last_name }
     email { Faker::Internet.email }

--- a/test/factories/parking_managers.rb
+++ b/test/factories/parking_managers.rb
@@ -1,5 +1,15 @@
 FactoryBot.define do
   factory :parking_manager do
     
+    first_name { Faker::JapaneseName.first_name }
+    last_name { Faker::JapaneseName.last_name }
+    email { Faker::Internet.email }
+    password { Faker::Internet.password }
+    prefecture { Faker::Address.prefecture }
+    city { Faker::Address.city }
+    street_address { Faker::Address.street_address }
+    phone_number { Faker::Number.number(digits: 11).to_s }
+    contact_number { Faker::Number.number(digits: 10).to_s }
+    terms_of_service { true }
   end
 end

--- a/test/factories/parking_managers.rb
+++ b/test/factories/parking_managers.rb
@@ -1,11 +1,11 @@
 FactoryBot.define do
   factory :parking_manager do
     
-    first_name { Faker::JapaneseName.first_name }
-    last_name { Faker::JapaneseName.last_name }
+    first_name { Faker::Name.first_name }
+    last_name { Faker::Name.last_name }
     email { Faker::Internet.email }
     password { Faker::Internet.password }
-    prefecture { Faker::Address.prefecture }
+    prefecture { I18n.t("prefectures").values.sample }
     city { Faker::Address.city }
     street_address { Faker::Address.street_address }
     phone_number { Faker::Number.number(digits: 11).to_s }


### PR DESCRIPTION
closes #285 
## 概要
アカウント作成のテストコードの実装

## 内容
Rspecでのparking_manager 作成時のバリデーションテストコードを実装しました。

### 成功パターン
- [ ] 全てのバリデーションが成功の時

### 失敗パターン
- [ ] first_nameが21文字以上の場合
- [ ] first_nameが空欄の場合
- [ ] last_nameが21文字以上の場合
- [ ] last_nameが空欄の場合
- [ ] emailが51文字以上だった場合
- [ ] emailが空欄だった場合
- [ ] prefectureが選択されていない場合
- [ ] cityが21文字以上の場合
- [ ] cityが空欄の場合
- [ ] street_addressが51文字以上の場合
- [ ] street_addressが空欄の場合
- [ ] buildingが56文字以上の場合
- [ ] phone_numberが11文字数以外だった場合
- [ ] phone_numberが数字以外だった場合
- [ ] phone_numberが空欄だった場合
- [ ] phone_numberが他のユーザーと重複した場合
- [ ] contact_numberが10文字以上11文字以内でなかった場合
- [ ] contact_numberが数字以外だった場合
- [ ] 利用規約の同意がチェックされていなかった場合