### PR TITLE
Feature/rspec parking lot

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -20,7 +20,7 @@ default: &default
   max_connections: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   host: db
   username: postgres
-  password: postgres
+  password: password
 
 development:
   <<: *default

--- a/spec/models/parking_lot_spec.rb
+++ b/spec/models/parking_lot_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ParkingLot, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/parking_lot_spec.rb
+++ b/spec/models/parking_lot_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe ParkingLot, type: :model do
         expect(parking_lot).to be_invalid
       end
 
-      it 'total_specesが100以上だった場合' do
+      it 'total_spacesが100以上だった場合' do
         parking_lot.total_spaces = 100
         expect(parking_lot).to be_invalid
       end

--- a/spec/models/parking_lot_spec.rb
+++ b/spec/models/parking_lot_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe ParkingLot, type: :model do
     # 成功パターン
     context 'バリデーション' do 
       it '設定した全てのバリデーションが機能しているか' do
+        expect(parking_lot).to be_valid
       end
     end
 

--- a/spec/models/parking_lot_spec.rb
+++ b/spec/models/parking_lot_spec.rb
@@ -61,6 +61,8 @@ RSpec.describe ParkingLot, type: :model do
       end
 
       it 'total_spacesが数字以外だった場合' do
+        parking_lot.total_spaces = 'あ'
+        expect(parking_lot).to be_invalid
       end
 
       it 'total_spacesが0だった場合' do

--- a/spec/models/parking_lot_spec.rb
+++ b/spec/models/parking_lot_spec.rb
@@ -50,8 +50,9 @@ RSpec.describe ParkingLot, type: :model do
         expect(parking_lot).to be_invalid
       end
 
-
       it 'descriptionが151文字以上だった場合' do
+        parking_lot.description = 'あ' * 151
+        expect(parking_lot).to be_invalid
       end
 
       it 'total_specesが100以上だった場合' do

--- a/spec/models/parking_lot_spec.rb
+++ b/spec/models/parking_lot_spec.rb
@@ -56,16 +56,21 @@ RSpec.describe ParkingLot, type: :model do
       end
 
       it 'total_specesが100以上だった場合' do
-        parking_lot.total_spaces = '100'
+        parking_lot.total_spaces = 100
         expect(parking_lot).to be_invalid
       end
 
       it 'total_spacesが数字以外だった場合' do
         parking_lot.total_spaces = 'あ'
         expect(parking_lot).to be_invalid
+
+        parking_lot.total_spaces = '!'
+        expect(parking_lot).to be_invalid
       end
 
       it 'total_spacesが0だった場合' do
+        parking_lot.total_spaces = 0
+        expect(parking_lot).to be_invalid
       end
 
       it 'total_spacesが空欄だった場合' do 

--- a/spec/models/parking_lot_spec.rb
+++ b/spec/models/parking_lot_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe ParkingLot, type: :model do
     # 失敗パターン
     context 'バリデーション' do
       it 'nameが41文字以上だった場合' do
+        parking_lot.name = 'あ' * 41
+        expect(parking_lot).to be_invalid
       end
 
       it 'prefectureが選択されていない場合' do 

--- a/spec/models/parking_lot_spec.rb
+++ b/spec/models/parking_lot_spec.rb
@@ -74,6 +74,8 @@ RSpec.describe ParkingLot, type: :model do
       end
 
       it 'total_spacesが空欄だった場合' do 
+        parking_lot.total_spaces = nil
+        expect(parking_lot).to be_invalid
       end
     end
   end

--- a/spec/models/parking_lot_spec.rb
+++ b/spec/models/parking_lot_spec.rb
@@ -89,6 +89,8 @@ RSpec.describe ParkingLot, type: :model do
       end
 
       it 'parking_managerが紐づいていない場合' do
+        parking_lot.parking_manager = nil
+        expect(parking_lot).to be_invalid
       end
     end
   end
@@ -100,6 +102,11 @@ RSpec.describe ParkingLot, type: :model do
         parking_area = create(:parking_area, parking_lot: parking_lot)
 
         expect { parking_lot.destroy }.to change(ParkingArea, :count).by(-1)
+      end
+    end
+
+    context 'parking_spaceが一度でも契約された場合' do
+      it '契約中のスペースがある場合、ParkingAreaも削除されずに残るか' do
       end
     end
   end

--- a/spec/models/parking_lot_spec.rb
+++ b/spec/models/parking_lot_spec.rb
@@ -12,9 +12,13 @@ RSpec.describe ParkingLot, type: :model do
       end
 
       it 'total_spacesが1だった場合' do
+        parking_lot.total_spaces = 1
+        expect(parking_lot).to be_valid
       end
 
       it 'total_spacesが99だった場合' do
+        parking_lot.total_spaces = 99
+        expect(parking_lot).to be_valid
       end
 
       it 'parking_lotが削除されるとparking_areaも削除される' do

--- a/spec/models/parking_lot_spec.rb
+++ b/spec/models/parking_lot_spec.rb
@@ -19,6 +19,11 @@ RSpec.describe ParkingLot, type: :model do
         expect(parking_lot).to be_invalid
       end
 
+      it 'nameが空欄だった場合' do
+        parking_lot.name = nil
+        expect(parking_lot).to be_invalid
+      end
+
       it 'prefectureが選択されていない場合' do 
       end
 

--- a/spec/models/parking_lot_spec.rb
+++ b/spec/models/parking_lot_spec.rb
@@ -36,6 +36,8 @@ RSpec.describe ParkingLot, type: :model do
       end
 
       it 'cityが空欄の場合' do
+        parking_lot.city = nil
+        expect(parking_lot).to be_invalid
       end
 
       it 'street_addressが51文字以上の場合' do

--- a/spec/models/parking_lot_spec.rb
+++ b/spec/models/parking_lot_spec.rb
@@ -25,6 +25,9 @@ RSpec.describe ParkingLot, type: :model do
       end
 
       it 'prefectureが選択されていない場合' do 
+        parking_lot.prefecture = nil
+        expect(parking_lot).to be_invalid
+        expect(parking_lot.errors[:prefecture]).to contain_exactly("を正しく選択してください")
       end
 
       it 'cityが21文字以上の場合' do

--- a/spec/models/parking_lot_spec.rb
+++ b/spec/models/parking_lot_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ParkingLot, type: :model do
     let(:parking_lot) { FactoryBot.build(:parking_lot) }
 
     # 成功パターン
-    context 'バリデーション' do 
+    context 'バリデーション' do
       it '設定した全てのバリデーションが機能しているか' do
         expect(parking_lot).to be_valid
       end
@@ -34,7 +34,7 @@ RSpec.describe ParkingLot, type: :model do
         expect(parking_lot).to be_invalid
       end
 
-      it 'prefectureが選択されていない場合' do 
+      it 'prefectureが選択されていない場合' do
         parking_lot.prefecture = nil
         expect(parking_lot).to be_invalid
         expect(parking_lot.errors[:prefecture]).to contain_exactly("を正しく選択してください")
@@ -83,7 +83,7 @@ RSpec.describe ParkingLot, type: :model do
         expect(parking_lot).to be_invalid
       end
 
-      it 'total_spacesが空欄だった場合' do 
+      it 'total_spacesが空欄だった場合' do
         parking_lot.total_spaces = nil
         expect(parking_lot).to be_invalid
       end
@@ -106,7 +106,7 @@ RSpec.describe ParkingLot, type: :model do
     end
 
     context 'parking_spaceが一度でも契約された場合' do
-      it '契約中のスペースがある場合、ParkingAreaも削除されずに残るか' do
+      it '契約中のスペースがある場合、ParkingAreaも削除されずに残る' do
         parking_lot = create(:parking_lot)
         parking_area = create(:parking_area, parking_lot: parking_lot)
         parking_space = create(:parking_space, parking_lot: parking_lot, parking_area: parking_area)

--- a/spec/models/parking_lot_spec.rb
+++ b/spec/models/parking_lot_spec.rb
@@ -56,6 +56,8 @@ RSpec.describe ParkingLot, type: :model do
       end
 
       it 'total_specesが100以上だった場合' do
+        parking_lot.total_spaces = '100'
+        expect(parking_lot).to be_invalid
       end
 
       it 'total_spacesが数字以外だった場合' do

--- a/spec/models/parking_lot_spec.rb
+++ b/spec/models/parking_lot_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ParkingLot, type: :model do
   describe 'create' do
     let(:parking_manager) { FactoryBot.create(:parking_manager) }
     let(:parking_lot) { FactoryBot.build(:parking_lot) }
-    
+
     # 成功パターン
     context 'バリデーション' do 
       it '設定した全てのバリデーションが機能しているか' do
@@ -19,9 +19,6 @@ RSpec.describe ParkingLot, type: :model do
       it 'total_spacesが99だった場合' do
         parking_lot.total_spaces = 99
         expect(parking_lot).to be_valid
-      end
-
-      it 'parking_lotが削除されるとparking_areaも削除される' do
       end
     end
 
@@ -92,6 +89,17 @@ RSpec.describe ParkingLot, type: :model do
       end
 
       it 'parking_managerが紐づいていない場合' do
+      end
+    end
+  end
+
+  describe 'アソシエーション' do
+    context 'parking_spaceが契約がされていない場合' do
+      it 'parking_lotが削除されるとparking_areasも削除される' do
+        parking_lot = create(:parking_lot)
+        parking_area = create(:parking_area, parking_lot: parking_lot)
+
+        expect { parking_lot.destroy }.to change(ParkingArea, :count).by(-1)
       end
     end
   end

--- a/spec/models/parking_lot_spec.rb
+++ b/spec/models/parking_lot_spec.rb
@@ -41,6 +41,8 @@ RSpec.describe ParkingLot, type: :model do
       end
 
       it 'street_addressが51文字以上の場合' do
+        parking_lot.street_address = 'あ' * 51
+        expect(parking_lot).to be_invalid
       end
 
       it 'street_addressが空欄の場合' do

--- a/spec/models/parking_lot_spec.rb
+++ b/spec/models/parking_lot_spec.rb
@@ -46,6 +46,8 @@ RSpec.describe ParkingLot, type: :model do
       end
 
       it 'street_addressが空欄の場合' do
+        parking_lot.street_address = nil
+        expect(parking_lot).to be_invalid
       end
 
 

--- a/spec/models/parking_lot_spec.rb
+++ b/spec/models/parking_lot_spec.rb
@@ -31,6 +31,8 @@ RSpec.describe ParkingLot, type: :model do
       end
 
       it 'cityが21文字以上の場合' do
+        parking_lot.city = 'あ' * 21
+        expect(parking_lot).to be_invalid
       end
 
       it 'cityが空欄の場合' do

--- a/spec/models/parking_lot_spec.rb
+++ b/spec/models/parking_lot_spec.rb
@@ -1,5 +1,51 @@
 require 'rails_helper'
 
 RSpec.describe ParkingLot, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'create' do
+    let(:parking_manager) { FactoryBot.create(:parking_manager) }
+    let(:parking_lot) { FactoryBot.build(:parking_lot) }
+    
+    # 成功パターン
+    context 'バリデーション' do 
+      it '設定した全てのバリデーションが機能しているか' do
+      end
+    end
+
+    # 失敗パターン
+    context 'バリデーション' do
+      it 'nameが41文字以上だった場合' do
+      end
+
+      it 'prefectureが選択されていない場合' do 
+      end
+
+      it 'cityが21文字以上の場合' do
+      end
+
+      it 'cityが空欄の場合' do
+      end
+
+      it 'street_addressが51文字以上の場合' do
+      end
+
+      it 'street_addressが空欄の場合' do
+      end
+
+
+      it 'descriptionが151文字以上だった場合' do
+      end
+
+      it 'total_specesが100以上だった場合' do
+      end
+
+      it 'total_spacesが数字以外だった場合' do
+      end
+
+      it 'total_spacesが0だった場合' do
+      end
+
+      it 'total_spacesが空欄だった場合' do 
+      end
+    end
+  end
 end

--- a/spec/models/parking_lot_spec.rb
+++ b/spec/models/parking_lot_spec.rb
@@ -107,6 +107,13 @@ RSpec.describe ParkingLot, type: :model do
 
     context 'parking_spaceが一度でも契約された場合' do
       it '契約中のスペースがある場合、ParkingAreaも削除されずに残るか' do
+        parking_lot = create(:parking_lot)
+        parking_area = create(:parking_area, parking_lot: parking_lot)
+        parking_space = create(:parking_space, parking_lot: parking_lot, parking_area: parking_area)
+        create(:contract_parking_space, parking_space: parking_space)
+
+        expect { parking_lot.destroy }.to raise_error(ActiveRecord::DeleteRestrictionError)
+        expect(ParkingArea.exists?(parking_area.id)).to be true
       end
     end
   end

--- a/spec/models/parking_lot_spec.rb
+++ b/spec/models/parking_lot_spec.rb
@@ -10,6 +10,15 @@ RSpec.describe ParkingLot, type: :model do
       it '設定した全てのバリデーションが機能しているか' do
         expect(parking_lot).to be_valid
       end
+
+      it 'total_spacesが1だった場合' do
+      end
+
+      it 'total_spacesが99だった場合' do
+      end
+
+      it 'parking_lotが削除されるとparking_areaも削除される' do
+      end
     end
 
     # 失敗パターン
@@ -76,6 +85,9 @@ RSpec.describe ParkingLot, type: :model do
       it 'total_spacesが空欄だった場合' do 
         parking_lot.total_spaces = nil
         expect(parking_lot).to be_invalid
+      end
+
+      it 'parking_managerが紐づいていない場合' do
       end
     end
   end

--- a/test/factories/contract_parking_spaces.rb
+++ b/test/factories/contract_parking_spaces.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :contract_parking_space do
+    
+  end
+end

--- a/test/factories/contract_parking_spaces.rb
+++ b/test/factories/contract_parking_spaces.rb
@@ -1,5 +1,9 @@
 FactoryBot.define do
   factory :contract_parking_space do
-    
+    start_date { Date.today }
+    end_date { 1.month.from_now }
+    association :parking_manager
+    association :parking_space
+    association :contractor
   end
 end

--- a/test/factories/parking_areas.rb
+++ b/test/factories/parking_areas.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :parking_area do
+
+  end
+end

--- a/test/factories/parking_areas.rb
+++ b/test/factories/parking_areas.rb
@@ -1,5 +1,8 @@
 FactoryBot.define do
   factory :parking_area do
-
+    name { Faker::Name.name }
+    default_price = 5000
+    association :parking_lot
+    category = 0
   end
 end

--- a/test/factories/parking_lots.rb
+++ b/test/factories/parking_lots.rb
@@ -1,5 +1,10 @@
 FactoryBot.define do
   factory :parking_lot do
-    
+    name { FactoryBot::Name name }
+    prefecture { I18n.t("prefectures").values.sample }
+    city { Faker::Address.city }
+    street_address { Faker::Address.street_address }
+    total_spaces { Faker::Number.number(digits: 2).to_s }
+    association :parking_manager
   end
 end

--- a/test/factories/parking_lots.rb
+++ b/test/factories/parking_lots.rb
@@ -1,10 +1,10 @@
 FactoryBot.define do
   factory :parking_lot do
-    name { FactoryBot::Name name }
+    name { Faker::Name.name }
     prefecture { I18n.t("prefectures").values.sample }
     city { Faker::Address.city }
     street_address { Faker::Address.street_address }
-    total_spaces { Faker::Number.number(digits: 2).to_s }
+    total_spaces { Faker::Number.number(digits: 2) }
     association :parking_manager
   end
 end

--- a/test/factories/parking_lots.rb
+++ b/test/factories/parking_lots.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :parking_lot do
+    
+  end
+end

--- a/test/factories/parking_spaces.rb
+++ b/test/factories/parking_spaces.rb
@@ -1,5 +1,10 @@
 FactoryBot.define do
   factory :parking_space do
-    
+    name { Faker::Number.number(digits:2) }
+    width { Faker::Number.number(digits: 1) }
+    length { Faker::Number.number(digits: 1) }
+    price = 5000
+    status = 0
+    association :parking_area
   end
 end

--- a/test/factories/parking_spaces.rb
+++ b/test/factories/parking_spaces.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :parking_space do
-    name { Faker::Number.number(digits:2) }
+    name { Faker::Number.number(digits: 2) }
     width { Faker::Number.number(digits: 1) }
     length { Faker::Number.number(digits: 1) }
     price = 5000

--- a/test/factories/parking_spaces.rb
+++ b/test/factories/parking_spaces.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :parking_space do
+    
+  end
+end


### PR DESCRIPTION
closes #299 
## 概要
ParkingLotのModelテストコードの実装

## 内容
RSpecとFakerを使用してParkingLotのModelテストを実装しました。

## 作成したFactoryBotファイル
- [ ] parking_lot
- [ ] parking_area
- [ ] parking_space
- [ ] contract_parking_space

## テスト条件: 成功
- [ ] バリデーション
- 設定した全てのバリデーションが機能しているか
- total_spacesが1だった場合
- total_spacesが99だった場合

- [ ] アソシエーション
- parking_lotが削除されるとparking_areasも削除される
- 契約中のスペースがある場合、ParkingAreaも削除されずに残る

## テスト条件: 失敗
- [ ] バリデーション
- nameが41文字以上だった場合
- nameが空欄だった場合
- prefectureが選択されていない場合
- cityが21文字以上の場合
- cityが空欄の場合
- street_addressが51文字以上の場合
- street_addressが空欄の場合
- descriptionが151文字以上だった場合
- total_spacesが100以上だった場合
- total_spacesが数字以外だった場合
- total_spacesが0だった場合
- total_spacesが空欄だった場合
- parking_managerが紐づいていない場合