### PR TITLE
01 update rspec contractor

### DIFF
--- a/app/models/contractor.rb
+++ b/app/models/contractor.rb
@@ -19,7 +19,7 @@ class Contractor < ApplicationRecord
   validates :notes, length: { maximum: 150 }
   validates :parking_manager, presence: true
 
-  has_many :contract_parking_spaces, dependent: :destroy
+  has_many :contract_parking_spaces, dependent: :restrict_with_exception
   has_many :active_contract_parking_spaces, -> {
     where("end_date >= ?", Date.current)
   }, class_name: "ContractParkingSpace"

--- a/spec/models/contractor_spec.rb
+++ b/spec/models/contractor_spec.rb
@@ -31,6 +31,8 @@ RSpec.describe Contractor, type: :model do
       end
 
       it 'cityが20文字だった場合' do
+        contractor.city = 'あ' * 20
+        expect(contractor).to be_valid
       end
 
       it 'street_addressが50文字だった場合' do

--- a/spec/models/contractor_spec.rb
+++ b/spec/models/contractor_spec.rb
@@ -128,10 +128,12 @@ RSpec.describe Contractor, type: :model do
         expect(contractor_1).to be_invalid
       end
 
-      it 'contact_numberが10文字以上11文字以内でなかった場合' do
+      it 'contact_numberが9文字だった場合' do
         contractor.contact_number = '1' * 9
         expect(contractor).to be_invalid
+      end
 
+      it 'contact_numberが12文字だった場合' do
         contractor.contact_number = '1' * 12
         expect(contractor).to be_invalid
       end

--- a/spec/models/contractor_spec.rb
+++ b/spec/models/contractor_spec.rb
@@ -118,6 +118,8 @@ RSpec.describe Contractor, type: :model do
       end
 
       it 'parking_managerが紐づいていない場合' do
+        contractor.parking_manager = nil
+        expect(contractor).to be_invalid
       end
     end
   end

--- a/spec/models/contractor_spec.rb
+++ b/spec/models/contractor_spec.rb
@@ -116,6 +116,9 @@ RSpec.describe Contractor, type: :model do
         contractor.notes = 'あ' * 151
         expect(contractor).to be_invalid
       end
+
+      it 'parking_managerが紐づいていない場合' do
+      end
     end
   end
 end

--- a/spec/models/contractor_spec.rb
+++ b/spec/models/contractor_spec.rb
@@ -19,6 +19,33 @@ RSpec.describe Contractor, type: :model do
 
         expect(contractor_1).to be_valid
       end
+
+      it 'first_nameが20文字だった場合' do
+      end
+
+      it 'last_nameが20文字だった場合' do
+      end
+
+      it 'cityが20文字だった場合' do
+      end
+
+      it 'street_addressが50文字だった場合' do
+      end
+
+      it 'buildingが55文字だった場合' do
+      end
+
+      it 'phone_numberが11文字だった場合' do
+      end
+
+      it 'contact_numberが10文字だった場合' do
+      end
+
+      it 'contact_numberが11文字だった場合' do
+      end
+
+      it 'notesが150文字だった場合' do
+      end
     end
 
     # 失敗パターン
@@ -91,7 +118,7 @@ RSpec.describe Contractor, type: :model do
 
       it 'phone_numberが空欄だった場合' do
         contractor.phone_number = nil
-       expect(contractor).to be_invalid
+        expect(contractor).to be_invalid
       end
 
       it '同じ管理者でphone_numberが他のユーザーと重複した場合' do
@@ -123,6 +150,11 @@ RSpec.describe Contractor, type: :model do
         contractor.parking_manager = nil
         expect(contractor).to be_invalid
       end
+    end
+  end
+
+  describe 'アソシエーション' do
+    it '契約履歴がある場合、削除されない' do
     end
   end
 end

--- a/spec/models/contractor_spec.rb
+++ b/spec/models/contractor_spec.rb
@@ -46,6 +46,8 @@ RSpec.describe Contractor, type: :model do
       end
 
       it 'phone_numberが11文字だった場合' do
+        contractor.phone_number = '1' * 11
+        expect(contractor).to be_valid
       end
 
       it 'contact_numberが10文字だった場合' do

--- a/spec/models/contractor_spec.rb
+++ b/spec/models/contractor_spec.rb
@@ -26,6 +26,8 @@ RSpec.describe Contractor, type: :model do
       end
 
       it 'last_nameが20文字だった場合' do
+        contractor.last_name = 'あ' * 20
+        expect(contractor).to be_valid
       end
 
       it 'cityが20文字だった場合' do

--- a/spec/models/contractor_spec.rb
+++ b/spec/models/contractor_spec.rb
@@ -51,6 +51,8 @@ RSpec.describe Contractor, type: :model do
       end
 
       it 'contact_numberが10文字だった場合' do
+        contractor.contact_number = '1' * 10
+        expect(contractor).to be_valid
       end
 
       it 'contact_numberが11文字だった場合' do

--- a/spec/models/contractor_spec.rb
+++ b/spec/models/contractor_spec.rb
@@ -56,6 +56,8 @@ RSpec.describe Contractor, type: :model do
       end
 
       it 'contact_numberが11文字だった場合' do
+        contractor.contact_number = '1' * 11
+        expect(contractor).to be_valid
       end
 
       it 'notesが150文字だった場合' do

--- a/spec/models/contractor_spec.rb
+++ b/spec/models/contractor_spec.rb
@@ -174,7 +174,11 @@ RSpec.describe Contractor, type: :model do
   end
 
   describe 'アソシエーション' do
-    it '契約履歴がある場合、削除されない' do
+    it '契約履歴がある場合、契約者は削除されない' do
+      contractor = create(:contractor)
+      contract = create(:contract_parking_space, contractor: contractor)
+
+      expect { contractor.destroy! }.to raise_error(ActiveRecord::DeleteRestrictionError)
     end
   end
 end

--- a/spec/models/contractor_spec.rb
+++ b/spec/models/contractor_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe Contractor, type: :model do
       end
 
       it 'first_nameが20文字だった場合' do
+        contractor.first_name = 'あ' * 20
+        expect(contractor).to be_valid
       end
 
       it 'last_nameが20文字だった場合' do

--- a/spec/models/contractor_spec.rb
+++ b/spec/models/contractor_spec.rb
@@ -36,6 +36,8 @@ RSpec.describe Contractor, type: :model do
       end
 
       it 'street_addressが50文字だった場合' do
+        contractor.street_address = 'あ' * 50
+        expect(contractor).to be_valid
       end
 
       it 'buildingが55文字だった場合' do

--- a/spec/models/contractor_spec.rb
+++ b/spec/models/contractor_spec.rb
@@ -61,6 +61,8 @@ RSpec.describe Contractor, type: :model do
       end
 
       it 'notesが150文字だった場合' do
+        contractor.notes = 'あ' * 150
+        expect(contractor).to be_valid
       end
     end
 

--- a/spec/models/contractor_spec.rb
+++ b/spec/models/contractor_spec.rb
@@ -74,10 +74,12 @@ RSpec.describe Contractor, type: :model do
         expect(contractor).to be_invalid
       end
 
-      it 'phone_numberが11文字数以外だった場合' do
+      it 'phone_numberが10文字の場合' do
         contractor.phone_number = '1' * 10
         expect(contractor).to be_invalid
+      end
 
+      it 'phone_numberが12文字の場合' do
         contractor.phone_number = '1' * 12
         expect(contractor).to be_invalid
       end

--- a/spec/models/contractor_spec.rb
+++ b/spec/models/contractor_spec.rb
@@ -41,6 +41,8 @@ RSpec.describe Contractor, type: :model do
       end
 
       it 'buildingが55文字だった場合' do
+        contractor.building = 'あ' * 55
+        expect(contractor).to be_valid
       end
 
       it 'phone_numberが11文字だった場合' do


### PR DESCRIPTION
# 概要
contractorのModelテストの条件追加

# 内容
ContractorのModelテストに新しい条件を追加しました。

Modelのアソシエーションを変更
- [ ] has_many :contract_parking_spaces
- 設計ではdestoryになっており契約状態だった場合でも削除される設計でになっていたので、ContractParkingSpaceに契約した場合、エラー処理されるように設計を変更した。

# テスト追加
## テスト条件: 成功
- [ ] バリデーション
- first_nameが20文字だった場合
- last_nameが20文字だった場合
- cityが20文字だった場合
- street_addressが50文字だった場合
- buildingが55文字だった場合
- phone_numberが11文字だった場合
- contact_numberが10文字だった場合
- contact_numberが11文字だった場合
- notesが150文字だった場合

- [ ] アソシエーション
- 契約履歴がある場合、契約者は削除されない

## テスト条件: 失敗
- [ ] バリデーション
- parking_managerが紐づいていない場合

# テスト変更点
- [ ] phone_numberが11文字以外だった場合のテスト
- phone_numberの文字数10文字と11文字を別し、それぞれテストする形式に変更

- [ ] contact_numberが10文字から11文字までのテスト
- contact_numberの文字数10文字と11文字を別し、それぞれテストする形式に変更