### PR TITLE
Feature/r spec parking area

### DIFF
--- a/app/controllers/parking_areas_controller.rb
+++ b/app/controllers/parking_areas_controller.rb
@@ -65,4 +65,4 @@ class ParkingAreasController < ApplicationController
     def set_parking_area
       @parking_area = @parking_lot.parking_areas.find(params[:id])
     end
-  end
+end

--- a/app/controllers/parking_areas_controller.rb
+++ b/app/controllers/parking_areas_controller.rb
@@ -36,23 +36,33 @@ class ParkingAreasController < ApplicationController
   end
 
   def destroy
-    @parking_area.destroy
-    redirect_to parking_lot_parking_areas_path(@parking_lot),
-      success: "エリアを削除しました。",
-      status: :see_other
+    begin
+      @parking_area.destroy!
+      flash[:success] = "#{@parking_area.name} が削除されました"
+      redirect_to parking_lot_parking_areas_path(@parking_lot), status: :see_other
+
+    rescue ActiveRecord::DeleteRestrictionError
+      flash[:alert] = "この駐車場には契約中の駐車スペースがあるため、削除することができません"
+      redirect_to parking_lot_parking_areas_path(@parking_lot), status: :see_other
+
+    rescue => e
+      logger.error "駐車場削除エラー: #{e.message}"
+      flash[:alert] = "システムエラーが発生したため削除できませんでした"
+      redirect_to parking_lot_parking_area_path(@parking_lot), status: :see_other
+    end
   end
 
-  private
+    private
 
-  def parking_area_params
-    params.require(:parking_area).permit(:name, :default_price, :category, :description)
-  end
+    def parking_area_params
+      params.require(:parking_area).permit(:name, :default_price, :category, :description)
+    end
 
-  def set_parking_lot
-    @parking_lot = current_parking_manager.parking_lots.find(params[:parking_lot_id])
-  end
+    def set_parking_lot
+      @parking_lot = current_parking_manager.parking_lots.find(params[:parking_lot_id])
+    end
 
-  def set_parking_area
-    @parking_area = @parking_lot.parking_areas.find(params[:id])
+    def set_parking_area
+      @parking_area = @parking_lot.parking_areas.find(params[:id])
+    end
   end
-end

--- a/spec/models/parking_area_spec.rb
+++ b/spec/models/parking_area_spec.rb
@@ -61,6 +61,8 @@ RSpec.describe ParkingArea, type: :model do
       end
 
       it 'descriptionが151文字以上だった場合' do
+        parking_area.description = 'あ' * 151
+        expect(parking_area).to be_invalid
       end
 
       it 'parking_lotが紐づいていなかった場合' do

--- a/spec/models/parking_area_spec.rb
+++ b/spec/models/parking_area_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ParkingArea, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/parking_area_spec.rb
+++ b/spec/models/parking_area_spec.rb
@@ -16,7 +16,15 @@ RSpec.describe ParkingArea, type: :model do
         expect(parking_area).to be_valid
       end
 
-      it '別の管理者と同じnamaだった場合' do
+      it '別の管理者と同じnameだった場合' do
+        parking_manager_1 = create(:parking_manager)
+        parking_manager_2 = create(:parking_manager)
+        parking_lot_1 = create(:parking_lot, parking_manager: parking_manager_1)
+        parking_lot_2 = create(:parking_lot, parking_manager: parking_manager_2)
+        parking_area_1 = create(:parking_area, name: 'エリア1', parking_lot: parking_lot_1)
+        parking_area_2 = build(:parking_area, name: 'エリア1', parking_lot: parking_lot_2)
+
+        expect(parking_area_2).to be_valid
       end
 
       it 'default_priceが数値だった場合' do

--- a/spec/models/parking_area_spec.rb
+++ b/spec/models/parking_area_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe ParkingArea, type: :model do
       end
 
       it 'nameが20文字だった場合' do
+        parking_area.name = 'あ' * 20
+        expect(parking_area).to be_valid
       end
 
       it 'default_priceが数字だった場合' do

--- a/spec/models/parking_area_spec.rb
+++ b/spec/models/parking_area_spec.rb
@@ -75,6 +75,10 @@ RSpec.describe ParkingArea, type: :model do
   describe 'アソシエーション' do
     context 'parking_spaceが契約がされていない場合' do
       it 'parking_areaを削除すると、parking_spaceも削除されるか' do
+        parking_area = create(:parking_area)
+        parking_space = create(:parking_space, parking_area: parking_area)
+      
+        expect { parking_area.destroy }.to change(ParkingSpace, :count).by(-1)
       end
     end
 

--- a/spec/models/parking_area_spec.rb
+++ b/spec/models/parking_area_spec.rb
@@ -30,6 +30,8 @@ RSpec.describe ParkingArea, type: :model do
     # 失敗パターン
     context 'バリデーション' do
       it 'nameが21文字以上だった場合' do
+        parking_area.name = 'あ' * 21
+        expect(parking_area).to be_invalid
       end
 
       it '同じnameが既に登録されていた場合' do

--- a/spec/models/parking_area_spec.rb
+++ b/spec/models/parking_area_spec.rb
@@ -84,6 +84,12 @@ RSpec.describe ParkingArea, type: :model do
 
     context 'parking_spaceが一度でも契約された場合' do
       it '契約中のスペースがある場合、ParkingAreaも削除されずに残る' do
+        parking_area = create(:parking_area)
+        parking_space = create(:parking_space, parking_area: parking_area)
+        create(:contract_parking_space, parking_space: parking_space)
+
+         expect { parking_area.destroy }.to raise_error(ActiveRecord::DeleteRestrictionError)
+         expect(ParkingSpace.exists?(parking_space.id)).to be true
       end
     end
   end

--- a/spec/models/parking_area_spec.rb
+++ b/spec/models/parking_area_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe ParkingArea, type: :model do
       it 'parking_areaを削除すると、parking_spaceも削除されるか' do
         parking_area = create(:parking_area)
         parking_space = create(:parking_space, parking_area: parking_area)
-      
+
         expect { parking_area.destroy }.to change(ParkingSpace, :count).by(-1)
       end
     end

--- a/spec/models/parking_area_spec.rb
+++ b/spec/models/parking_area_spec.rb
@@ -35,6 +35,9 @@ RSpec.describe ParkingArea, type: :model do
       end
 
       it '同じnameが既に登録されていた場合' do
+        parking_area = create(:parking_area, name: 'エリア1', parking_lot: parking_lot)
+        parking_area_1 = build(:parking_area, name: 'エリア1', parking_lot: parking_lot)
+        expect(parking_area_1).to be_invalid
       end
 
       it 'nameが空欄だった場合' do

--- a/spec/models/parking_area_spec.rb
+++ b/spec/models/parking_area_spec.rb
@@ -1,5 +1,61 @@
 require 'rails_helper'
 
 RSpec.describe ParkingArea, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'create' do
+    let(:parking_lot) { FactoryBot.create(:parking_lot) }
+    let(:parking_area) { FactoryBot.build(:parking_area) }
+
+    # 成功パターン
+    context 'バリデーション' do
+      it '設定した全てのバリデーションが機能しているか' do
+    end
+
+      it 'nameが20文字だった場合' do
+      end
+
+      it 'default_priceが数字だった場合' do
+      end
+
+      it 'descriptionが150文字だった場合' do
+      end
+    end
+
+    # 失敗パターン
+    context 'バリデーション' do
+      it 'nameが21文字以上だった場合' do
+      end
+
+      it '同じnameが既に登録されていた場合' do
+      end
+
+      it 'nameが空欄だった場合' do
+      end
+
+      it 'default_priceが文字だった場合' do
+      end
+
+      it 'default_priceが記号が入力されて場合' do
+    end
+
+      it 'default_priceが空欄だった場合' do
+      end
+
+      it 'descriptionが151文字以上だった場合' do
+      end
+
+      it 'parking_lotが紐づいていなかった場合' do
+      end
+    end
+
+     describe 'アソシエーション' do
+       context 'parking_spaceが契約がされていない場合' do
+         it 'parking_spaceが契約された場合、削除されない' do
+         end
+       end
+
+       context 'parking_spaceが一度でも契約された場合' do
+       it '契約中のスペースがある場合、ParkingAreaも削除されずに残る' do
+       end
+     end
+  end
 end

--- a/spec/models/parking_area_spec.rb
+++ b/spec/models/parking_area_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe ParkingArea, type: :model do
 
   describe 'アソシエーション' do
     context 'parking_spaceが契約がされていない場合' do
-      it 'parking_spaceが契約された場合、削除されない' do
+      it 'parking_areaを削除すると、parking_spaceも削除されるか' do
       end
     end
 

--- a/spec/models/parking_area_spec.rb
+++ b/spec/models/parking_area_spec.rb
@@ -22,6 +22,8 @@ RSpec.describe ParkingArea, type: :model do
       end
 
       it 'descriptionが150文字だった場合' do
+        parking_area.description = 'あ' * 150
+        expect(parking_area).to be_valid
       end
     end
 

--- a/spec/models/parking_area_spec.rb
+++ b/spec/models/parking_area_spec.rb
@@ -16,6 +16,9 @@ RSpec.describe ParkingArea, type: :model do
         expect(parking_area).to be_valid
       end
 
+      it '別の管理者と同じnamaだった場合' do
+      end
+
       it 'default_priceが数値だった場合' do
         parking_area.default_price = 5000
         expect(parking_area).to be_valid

--- a/spec/models/parking_area_spec.rb
+++ b/spec/models/parking_area_spec.rb
@@ -66,6 +66,8 @@ RSpec.describe ParkingArea, type: :model do
       end
 
       it 'parking_lotが紐づいていなかった場合' do
+        parking_area.parking_lot = nil
+        expect(parking_area).to be_invalid
       end
     end
   end

--- a/spec/models/parking_area_spec.rb
+++ b/spec/models/parking_area_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe ParkingArea, type: :model do
         expect(parking_area).to be_valid
       end
 
-      it 'default_priceが数字だった場合' do
+      it 'default_priceが数値だった場合' do
         parking_area.default_price = 5000
         expect(parking_area).to be_valid
       end
@@ -45,12 +45,14 @@ RSpec.describe ParkingArea, type: :model do
         expect(parking_area).to be_invalid
       end
 
-      it 'default_priceが文字だった場合' do
+      it 'default_priceが文字列だった場合' do
         parking_area.default_price = 'あ'
         expect(parking_area).to be_invalid
       end
 
-      it 'default_priceが記号が入力されて場合' do
+      it 'default_priceが記号が含まれていた場合' do
+        parking_area.default_price = '5000~'
+        expect(parking_area).to be_invalid
       end
 
       it 'default_priceが空欄だった場合' do

--- a/spec/models/parking_area_spec.rb
+++ b/spec/models/parking_area_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe ParkingArea, type: :model do
     # 成功パターン
     context 'バリデーション' do
       it '設定した全てのバリデーションが機能しているか' do
-    end
+        expect(parking_area).to be_valid
+      end
 
       it 'nameが20文字だった場合' do
       end
@@ -35,7 +36,7 @@ RSpec.describe ParkingArea, type: :model do
       end
 
       it 'default_priceが記号が入力されて場合' do
-    end
+      end
 
       it 'default_priceが空欄だった場合' do
       end
@@ -46,16 +47,17 @@ RSpec.describe ParkingArea, type: :model do
       it 'parking_lotが紐づいていなかった場合' do
       end
     end
+  end
 
-     describe 'アソシエーション' do
-       context 'parking_spaceが契約がされていない場合' do
-         it 'parking_spaceが契約された場合、削除されない' do
-         end
-       end
+  describe 'アソシエーション' do
+    context 'parking_spaceが契約がされていない場合' do
+      it 'parking_spaceが契約された場合、削除されない' do
+      end
+    end
 
-       context 'parking_spaceが一度でも契約された場合' do
-       it '契約中のスペースがある場合、ParkingAreaも削除されずに残る' do
-       end
-     end
+    context 'parking_spaceが一度でも契約された場合' do
+      it '契約中のスペースがある場合、ParkingAreaも削除されずに残る' do
+      end
+    end
   end
 end

--- a/spec/models/parking_area_spec.rb
+++ b/spec/models/parking_area_spec.rb
@@ -41,6 +41,8 @@ RSpec.describe ParkingArea, type: :model do
       end
 
       it 'nameが空欄だった場合' do
+        parking_area.name = nil
+        expect(parking_area).to be_invalid
       end
 
       it 'default_priceが文字だった場合' do

--- a/spec/models/parking_area_spec.rb
+++ b/spec/models/parking_area_spec.rb
@@ -46,6 +46,8 @@ RSpec.describe ParkingArea, type: :model do
       end
 
       it 'default_priceが文字だった場合' do
+        parking_area.default_price = 'あ'
+        expect(parking_area).to be_invalid
       end
 
       it 'default_priceが記号が入力されて場合' do

--- a/spec/models/parking_area_spec.rb
+++ b/spec/models/parking_area_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe ParkingArea, type: :model do
       end
 
       it 'default_priceが数字だった場合' do
+        parking_area.default_price = 5000
+        expect(parking_area).to be_valid
       end
 
       it 'descriptionが150文字だった場合' do

--- a/spec/models/parking_area_spec.rb
+++ b/spec/models/parking_area_spec.rb
@@ -56,6 +56,8 @@ RSpec.describe ParkingArea, type: :model do
       end
 
       it 'default_priceが空欄だった場合' do
+        parking_area.default_price = nil
+        expect(parking_area).to be_invalid
       end
 
       it 'descriptionが151文字以上だった場合' do

--- a/test/factories/parking_areas.rb
+++ b/test/factories/parking_areas.rb
@@ -3,6 +3,6 @@ FactoryBot.define do
     name { Faker::Name.name }
     default_price = 5000
     association :parking_lot
-    category = 0
+    category = asphalt
   end
 end

--- a/test/factories/parking_spaces.rb
+++ b/test/factories/parking_spaces.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     width { Faker::Number.number(digits: 1) }
     length { Faker::Number.number(digits: 1) }
     price = 5000
-    status = 0
+    status = 'available'
     association :parking_area
   end
 end

--- a/test/factories/parking_spaces.rb
+++ b/test/factories/parking_spaces.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     width { Faker::Number.number(digits: 1) }
     length { Faker::Number.number(digits: 1) }
     price = 5000
-    status = 'available'
+    status = "available"
     association :parking_area
   end
 end


### PR DESCRIPTION
closes #300 
# 概要
RSpecでのParking_areaのテストコードの実装

# 内容
RSpec・FactoryBotを使用してのテストコードを実装しました。
Controller_Parking_area.destroyの処理に例外処理エラーフローを追加。

## 変更点
- [ ] Controller_Parking_area.destroyの例外処理の追加
- parking_spaceが契約された、もしくは過去に契約していた場合："この駐車場には契約中の駐車スペースがあるため、削除することができません"
- 何らかの理由で削除処理がされなかった場合："システムエラーが発生したため削除できませんでした"

## テストコード: バリデーション
- [ ] 成功
- 設定した全てのバリデーションが機能しているか
- nameが20文字だった場合
- 別の管理者が同じnameだった場合
- default_priceが数値だった場合
- descriptionが150文字だった場合

- [ ] 失敗
- nameが21文字以上だった場合
- 同じnameが既に登録されていた場合
- nameが空欄だった場合
- default_priceが文字列だった場
- default_priceが記号が含まれていた場合
- default_priceが空欄だった場合
- descriptionが151文字以上だった場合
- parking_lotが紐づいていなかった場合

## テストコード：アソシエーション
- [ ] parking_spaceが契約していない場合
- parking_areaを削除すると、parking_spaceも削除されるか

- [ ] parking_spaceが一度でも契約された場合
- 契約中のスペースがある場合、ParkingAreaも削除されずに残る