### PR TITLE
Feature/r spec parking space

### DIFF
--- a/app/models/parking_space.rb
+++ b/app/models/parking_space.rb
@@ -11,7 +11,7 @@ class ParkingSpace < ApplicationRecord
   validates :parking_area, presence: true
   validates :price, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
 
-  validate :name_id_immutable_if_contracted, on: :update
+  validate :name_immutable_if_contracted, on: :update
 
   enum :status, { available: 0, contracted: 1, pending: 2, prohibited: 3 }, prefix: true, default: :available
 

--- a/app/models/parking_space.rb
+++ b/app/models/parking_space.rb
@@ -109,7 +109,7 @@ class ParkingSpace < ApplicationRecord
     end
   end
 
-  def name_id_immutable_if_contracted
+  def name_immutable_if_contracted
     if name_changed? && contract_parking_spaces.exists?
       errors.add(:name, "は契約実績があるため変更できません。")
     end

--- a/spec/models/parking_space_spec.rb
+++ b/spec/models/parking_space_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe ParkingSpace, type: :model do
       end
 
       it 'nameが10文字だった場合' do
+        parking_space.name = 'あ' * 10
+        expect(parking_space).to be_valid
       end
 
       it 'descriptionが150文字だった場合' do

--- a/spec/models/parking_space_spec.rb
+++ b/spec/models/parking_space_spec.rb
@@ -81,6 +81,8 @@ RSpec.describe ParkingSpace, type: :model do
       end
 
       it 'widthが文字列だった場合' do
+        parking_space.width = '一'
+        expect(parking_space).to be_invalid
       end
 
       it 'widthが空欄だった場合' do

--- a/spec/models/parking_space_spec.rb
+++ b/spec/models/parking_space_spec.rb
@@ -71,6 +71,8 @@ RSpec.describe ParkingSpace, type: :model do
       end
 
       it 'widthが-1だった場合' do
+        parking_space.width = '-1'
+        expect(parking_space).to be_invalid
       end
 
       it 'widthが10だった場合' do

--- a/spec/models/parking_space_spec.rb
+++ b/spec/models/parking_space_spec.rb
@@ -45,6 +45,9 @@ RSpec.describe ParkingSpace, type: :model do
         parking_space.price = 0
         expect(parking_space).to be_valid
       end
+
+      it 'priceが空欄だった場合' do
+      end
     end
 
     # 失敗パターン
@@ -118,9 +121,6 @@ RSpec.describe ParkingSpace, type: :model do
       it 'priceが小数だった場合' do
         parking_space.price = '1000.1'
         expect(parking_space).to be_invalid
-      end
-
-      it 'priceが空欄だった場合' do
       end
 
       it 'parking_areaが紐づいていなかった場合' do

--- a/spec/models/parking_space_spec.rb
+++ b/spec/models/parking_space_spec.rb
@@ -27,6 +27,8 @@ RSpec.describe ParkingSpace, type: :model do
       end
 
       it 'widthが9.9だった場合' do
+        parking_space.width = 9.9
+        expect(parking_space).to be_valid
       end
 
       it 'lengthが0だった場合' do

--- a/spec/models/parking_space_spec.rb
+++ b/spec/models/parking_space_spec.rb
@@ -91,6 +91,8 @@ RSpec.describe ParkingSpace, type: :model do
       end
 
       it 'lengthが-1だった場合' do
+        parking_space.length = '-1'
+        expect(parking_space).to be_invalid
       end
 
       it 'lengthが10だった場合' do

--- a/spec/models/parking_space_spec.rb
+++ b/spec/models/parking_space_spec.rb
@@ -110,7 +110,9 @@ RSpec.describe ParkingSpace, type: :model do
         expect(parking_space).to be_invalid
       end
 
-      it 'priceが-1だった場合' do
+      it 'priceが負の数値だった場合' do
+        parking_space.price = '-5000'
+        expect(parking_space).to be_invalid
       end
 
       it 'priceが小数だった場合' do

--- a/spec/models/parking_space_spec.rb
+++ b/spec/models/parking_space_spec.rb
@@ -101,6 +101,8 @@ RSpec.describe ParkingSpace, type: :model do
       end
 
       it 'lengthが文字列だった場合' do
+        parking_space.length = '二'
+        expect(parking_space).to be_invalid
       end
 
       it 'lengthが空欄だった場合' do

--- a/spec/models/parking_space_spec.rb
+++ b/spec/models/parking_space_spec.rb
@@ -76,6 +76,8 @@ RSpec.describe ParkingSpace, type: :model do
       end
 
       it 'widthが10だった場合' do
+        parking_space.width = 10
+        expect(parking_space).to be_invalid
       end
 
       it 'widthが文字列だった場合' do

--- a/spec/models/parking_space_spec.rb
+++ b/spec/models/parking_space_spec.rb
@@ -22,6 +22,8 @@ RSpec.describe ParkingSpace, type: :model do
       end
 
       it 'widthが0だった場合' do
+        parking_space.width = 0
+        expect(parking_space).to be_valid
       end
 
       it 'widthが9.9だった場合' do

--- a/spec/models/parking_space_spec.rb
+++ b/spec/models/parking_space_spec.rb
@@ -96,6 +96,8 @@ RSpec.describe ParkingSpace, type: :model do
       end
 
       it 'lengthが10だった場合' do
+        parking_space.length = 10
+        expect(parking_space).to be_invalid
       end
 
       it 'lengthが文字列だった場合' do

--- a/spec/models/parking_space_spec.rb
+++ b/spec/models/parking_space_spec.rb
@@ -61,6 +61,8 @@ RSpec.describe ParkingSpace, type: :model do
       end
 
       it 'nameが空欄だった場合' do
+        parking_space.name = nil
+        expect(parking_space).to be_invalid
       end
 
       it 'desctiptionが151文字以上だった場合' do

--- a/spec/models/parking_space_spec.rb
+++ b/spec/models/parking_space_spec.rb
@@ -1,9 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe ParkingSpace, type: :model do
-  describe 'create' do
     let(:parking_area) { FactoryBot.create(:parking_area) }   
     let(:parking_space) { FactoryBot.build(:parking_space) }
+
+  describe 'create' do
 
     # 成功パターン
     context 'バリデーション' do
@@ -135,6 +136,9 @@ RSpec.describe ParkingSpace, type: :model do
   describe 'update' do
     context 'バリデーション' do
       it '作成されたスペースのpriceを空欄にした場合' do
+        space = create(:parking_space, price: 5000, parking_area: parking_area)
+        space.update(price: nil)
+        expect(space).to be_invalid
       end
 
       context 'parking_spaceがcontractedの場合' do

--- a/spec/models/parking_space_spec.rb
+++ b/spec/models/parking_space_spec.rb
@@ -106,6 +106,8 @@ RSpec.describe ParkingSpace, type: :model do
       end
 
       it 'lengthが空欄だった場合' do
+        parking_space.length = nil
+        expect(parking_space).to be_invalid
       end
 
       it 'priceが-1だった場合' do

--- a/spec/models/parking_space_spec.rb
+++ b/spec/models/parking_space_spec.rb
@@ -50,6 +50,8 @@ RSpec.describe ParkingSpace, type: :model do
     # 失敗パターン
     context 'バリデーション' do
       it 'nameが11文字だった場合' do
+        parking_space.name = 'あ' * 11
+        expect(parking_space).to be_invalid
       end
 
       it 'nameが既に登録されていた場合' do

--- a/spec/models/parking_space_spec.rb
+++ b/spec/models/parking_space_spec.rb
@@ -120,9 +120,6 @@ RSpec.describe ParkingSpace, type: :model do
         expect(parking_space).to be_invalid
       end
 
-      it 'priceが文字列だった場合' do
-      end
-
       it 'priceが空欄だった場合' do
       end
 

--- a/spec/models/parking_space_spec.rb
+++ b/spec/models/parking_space_spec.rb
@@ -1,11 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe ParkingSpace, type: :model do
-    let(:parking_area) { FactoryBot.create(:parking_area) }   
+    let(:parking_area) { FactoryBot.create(:parking_area) }
     let(:parking_space) { FactoryBot.build(:parking_space) }
 
   describe 'create' do
-
     # 成功パターン
     context 'バリデーション' do
       it '設定した全てのバリデーションが機能しているか' do

--- a/spec/models/parking_space_spec.rb
+++ b/spec/models/parking_space_spec.rb
@@ -152,6 +152,9 @@ RSpec.describe ParkingSpace, type: :model do
 
       context 'parking_spaceが契約記録がない場合' do
         it 'nameが変更することができる' do
+          space = create(:parking_space, name: '1', parking_area: parking_area)
+          space.name = '2'
+          expect(space).to be_valid
         end
       end
     end

--- a/spec/models/parking_space_spec.rb
+++ b/spec/models/parking_space_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe ParkingSpace, type: :model do
     # 成功パターン
     context 'バリデーション' do
       it '設定した全てのバリデーションが機能しているか' do
+        expect(parking_space).to be_valid
       end
 
       it 'nameが10文字だった場合' do

--- a/spec/models/parking_space_spec.rb
+++ b/spec/models/parking_space_spec.rb
@@ -126,6 +126,8 @@ RSpec.describe ParkingSpace, type: :model do
       end
 
       it 'parking_areaが紐づいていなかった場合' do
+        parking_space.parking_area = nil
+        expect(parking_space).to be_invalid
       end
     end
   end

--- a/spec/models/parking_space_spec.rb
+++ b/spec/models/parking_space_spec.rb
@@ -32,6 +32,8 @@ RSpec.describe ParkingSpace, type: :model do
       end
 
       it 'lengthが0だった場合' do
+        parking_space.length = 0
+        expect(parking_space).to be_valid
       end
 
       it 'lengthが9.9だった場合' do

--- a/spec/models/parking_space_spec.rb
+++ b/spec/models/parking_space_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe ParkingSpace, type: :model do
       end
 
       it 'descriptionが150文字だった場合' do
+        parking_space.description = 'あ' * 150
+        expect(parking_space).to be_valid
       end
 
       it 'widthが0だった場合' do

--- a/spec/models/parking_space_spec.rb
+++ b/spec/models/parking_space_spec.rb
@@ -81,11 +81,13 @@ RSpec.describe ParkingSpace, type: :model do
       end
 
       it 'widthが文字列だった場合' do
-        parking_space.width = '一'
+        parking_space.width = '二'
         expect(parking_space).to be_invalid
       end
 
       it 'widthが空欄だった場合' do
+        parking_space.width = nil
+        expect(parking_space).to be_invalid
       end
 
       it 'lengthが-1だった場合' do

--- a/spec/models/parking_space_spec.rb
+++ b/spec/models/parking_space_spec.rb
@@ -161,9 +161,6 @@ RSpec.describe ParkingSpace, type: :model do
           expect(space).to be_invalid
         end
 
-        it '過去に一度でも契約した場合、nameを変更できずにそのであること' do
-        end
-
         it 'statusが"contracted"に変更されるか' do
           skip '未実装のため後日実装'
         end
@@ -174,6 +171,7 @@ RSpec.describe ParkingSpace, type: :model do
   describe 'アソシエーション' do
     context 'parking_spaceが一度でも駐車場契約された' do
       it 'parking_spaceを削除されずに残る' do
+
       end
     end
   end

--- a/spec/models/parking_space_spec.rb
+++ b/spec/models/parking_space_spec.rb
@@ -141,12 +141,16 @@ RSpec.describe ParkingSpace, type: :model do
         expect(space).to be_invalid
       end
 
-      context 'parking_spaceがcontractedの場合' do
+      context 'parking_spaceに契約記録がある場合' do
         it 'nameが変更を無効になる' do
+          space = create(:parking_space, name: '1', status: 'contracted', parking_area: parking_area)
+          create(:contract_parking_space, parking_space: space)
+          space.name = '2'
+          expect(space).to be_invalid
         end
       end
 
-      context 'parking_spaceがcontractedでない場合' do
+      context 'parking_spaceが契約記録がない場合' do
         it 'nameが変更することができる' do
         end
       end

--- a/spec/models/parking_space_spec.rb
+++ b/spec/models/parking_space_spec.rb
@@ -111,11 +111,13 @@ RSpec.describe ParkingSpace, type: :model do
       end
 
       it 'priceが負の数値だった場合' do
-        parking_space.price = '-5000'
+        parking_space.price = '-1000'
         expect(parking_space).to be_invalid
       end
 
       it 'priceが小数だった場合' do
+        parking_space.price = '1000.1'
+        expect(parking_space).to be_invalid
       end
 
       it 'priceが文字列だった場合' do

--- a/spec/models/parking_space_spec.rb
+++ b/spec/models/parking_space_spec.rb
@@ -134,22 +134,8 @@ RSpec.describe ParkingSpace, type: :model do
   end
 
   describe 'update' do
+    # 成功パターン
     context 'バリデーション' do
-      it '作成されたスペースのpriceを空欄にした場合' do
-        space = create(:parking_space, price: 5000, parking_area: parking_area)
-        space.update(price: nil)
-        expect(space).to be_invalid
-      end
-
-      context 'parking_spaceに契約記録がある場合' do
-        it 'nameが変更を無効になる' do
-          space = create(:parking_space, name: '1', status: 'contracted', parking_area: parking_area)
-          create(:contract_parking_space, parking_space: space)
-          space.name = '2'
-          expect(space).to be_invalid
-        end
-      end
-
       context 'parking_spaceが契約記録がない場合' do
         it 'nameが変更することができる' do
           space = create(:parking_space, name: '1', parking_area: parking_area)
@@ -159,15 +145,28 @@ RSpec.describe ParkingSpace, type: :model do
       end
     end
 
-    context 'parking_spaceが駐車場契約された時' do
-      it '現在契約しており、nameを変更でないずにそのままだあること' do
+    # 失敗パターン
+    context 'バリデーション' do
+      it '作成されたスペースのpriceを空欄にした場合' do
+        space = create(:parking_space, price: 5000, parking_area: parking_area)
+        space.update(price: nil)
+        expect(space).to be_invalid
       end
 
-      it '過去に一度でも契約した場合、nameを変更できずにそのであること' do
-      end
+      context 'parking_spaceが契約履歴がある時' do
+        it 'nameの変更を無効になる' do
+          space = create(:parking_space, name: '1', status: 'contracted', parking_area: parking_area)
+          create(:contract_parking_space, parking_space: space)
+          space.name = '2'
+          expect(space).to be_invalid
+        end
 
-      it 'statusが"contracted"に変更されるか' do
-        skip '未実装のため後日実装'
+        it '過去に一度でも契約した場合、nameを変更できずにそのであること' do
+        end
+
+        it 'statusが"contracted"に変更されるか' do
+          skip '未実装のため後日実装'
+        end
       end
     end
   end

--- a/spec/models/parking_space_spec.rb
+++ b/spec/models/parking_space_spec.rb
@@ -138,9 +138,9 @@ RSpec.describe ParkingSpace, type: :model do
     context 'バリデーション' do
       context 'parking_spaceが契約記録がない場合' do
         it 'nameが変更することができる' do
-          space = create(:parking_space, name: '1', parking_area: parking_area)
-          space.name = '2'
-          expect(space).to be_valid
+          parking_space = create(:parking_space, name: '1', parking_area: parking_area)
+          parking_space.name = '2'
+          expect(parking_space).to be_valid
         end
       end
     end
@@ -148,17 +148,17 @@ RSpec.describe ParkingSpace, type: :model do
     # 失敗パターン
     context 'バリデーション' do
       it '作成されたスペースのpriceを空欄にした場合' do
-        space = create(:parking_space, price: 5000, parking_area: parking_area)
-        space.update(price: nil)
-        expect(space).to be_invalid
+        parking_space = create(:parking_space, price: 5000, parking_area: parking_area)
+        parking_space.update(price: nil)
+        expect(parking_space).to be_invalid
       end
 
       context 'parking_spaceが契約履歴がある時' do
         it 'nameの変更を無効になる' do
-          space = create(:parking_space, name: '1', status: 'contracted', parking_area: parking_area)
-          create(:contract_parking_space, parking_space: space)
-          space.name = '2'
-          expect(space).to be_invalid
+          parking_space = create(:parking_space, name: '1', status: 'contracted', parking_area: parking_area)
+          create(:contract_parking_space, parking_space: parking_space)
+          parking_space.name = '2'
+          expect(parking_space).to be_invalid
         end
 
         it 'statusが"contracted"に変更されるか' do

--- a/spec/models/parking_space_spec.rb
+++ b/spec/models/parking_space_spec.rb
@@ -171,7 +171,10 @@ RSpec.describe ParkingSpace, type: :model do
   describe 'アソシエーション' do
     context 'parking_spaceが一度でも駐車場契約された' do
       it 'parking_spaceを削除されずに残る' do
-
+        parking_space = create(:parking_space, parking_area: parking_area)
+        create(:contract_parking_space, parking_space: parking_space)
+        expect { parking_space.destroy }.to raise_error(ActiveRecord::DeleteRestrictionError)
+         expect(ParkingSpace.exists?(parking_space.id)).to be true
       end
     end
   end

--- a/spec/models/parking_space_spec.rb
+++ b/spec/models/parking_space_spec.rb
@@ -42,6 +42,8 @@ RSpec.describe ParkingSpace, type: :model do
       end
 
       it 'priceが0だった場合' do
+        parking_space.price = 0
+        expect(parking_space).to be_valid
       end
     end
 

--- a/spec/models/parking_space_spec.rb
+++ b/spec/models/parking_space_spec.rb
@@ -55,6 +55,9 @@ RSpec.describe ParkingSpace, type: :model do
       end
 
       it 'nameが既に登録されていた場合' do
+        space_name = create(:parking_space, name: '1', parking_area: parking_area)
+        space_name_1 = build(:parking_space, name: '1', parking_area: parking_area)
+        expect(space_name_1).to be_invalid
       end
 
       it 'nameが空欄だった場合' do

--- a/spec/models/parking_space_spec.rb
+++ b/spec/models/parking_space_spec.rb
@@ -1,0 +1,116 @@
+require 'rails_helper'
+
+RSpec.describe ParkingSpace, type: :model do
+  describe 'create' do
+    let(:parking_area) { FactoryBot.create(:parking_area) }   
+    let(:parking_space) { FactoryBot.build(:parking_space) }
+
+    # 成功パターン
+    context 'バリデーション' do
+      it '設定した全てのバリデーションが機能しているか' do
+      end
+
+      it 'nameが10文字だった場合' do
+      end
+
+      it 'descriptionが150文字だった場合' do
+      end
+
+      it 'widthが0だった場合' do
+      end
+
+      it 'widthが9.9だった場合' do
+      end
+
+      it 'lengthが0だった場合' do
+      end
+
+      it 'lengthが9.9だった場合' do
+      end
+
+      it 'priceが0だった場合' do
+      end
+    end
+
+    # 失敗パターン
+    context 'バリデーション' do
+      it 'nameが11文字だった場合' do
+      end
+
+      it 'nameが既に登録されていた場合' do
+      end
+
+      it 'nameが空欄だった場合' do
+      end
+
+      it 'desctiptionが151文字以上だった場合' do
+      end
+
+      it 'widthが-1だった場合' do
+      end
+
+      it 'widthが10だった場合' do
+      end
+
+      it 'widthが文字列だった場合' do
+      end
+
+      it 'widthが空欄だった場合' do
+      end
+
+      it 'lengthが-1だった場合' do
+      end
+
+      it 'lengthが10だった場合' do
+      end
+
+      it 'lengthが文字列だった場合' do
+      end
+
+      it 'lengthが空欄だった場合' do
+      end
+
+      it 'priceが-1だった場合' do
+      end
+
+      it 'priceが小数だった場合' do
+      end
+
+      it 'priceが文字列だった場合' do
+      end
+
+      it 'priceが空欄だった場合' do
+      end
+
+      it 'parking_areaが紐づいていなかった場合' do
+      end
+    end
+  end
+
+  describe 'update' do
+    context 'バリデーション' do
+      context 'parking_spaceがcontractedの場合' do
+        it 'nameが変更を無効になる' do
+        end
+      end
+
+      context 'parking_spaceがcontractedでない場合' do
+        it 'nameが変更することができる' do
+        end
+      end
+    end
+
+    context 'parking_spaceが駐車場契約された時' do
+      it 'statusが"contracted"に変更されるか' do
+        skip '未実装のため後日実装'
+      end
+    end
+  end
+
+  describe 'アソシエーション' do
+    context 'parking_spaceが一度でも駐車場契約された' do
+      it 'parking_spaceを削除されずに残る' do
+      end
+    end
+  end
+end

--- a/spec/models/parking_space_spec.rb
+++ b/spec/models/parking_space_spec.rb
@@ -47,6 +47,8 @@ RSpec.describe ParkingSpace, type: :model do
       end
 
       it 'priceが空欄だった場合' do
+        parking_space.price = nil
+        expect(parking_space).to be_valid
       end
     end
 
@@ -130,6 +132,9 @@ RSpec.describe ParkingSpace, type: :model do
 
   describe 'update' do
     context 'バリデーション' do
+      it '作成されたスペースのpriceを空欄にした場合' do
+      end
+
       context 'parking_spaceがcontractedの場合' do
         it 'nameが変更を無効になる' do
         end
@@ -142,6 +147,12 @@ RSpec.describe ParkingSpace, type: :model do
     end
 
     context 'parking_spaceが駐車場契約された時' do
+      it '現在契約しており、nameを変更でないずにそのままだあること' do
+      end
+
+      it '過去に一度でも契約した場合、nameを変更できずにそのであること' do
+      end
+
       it 'statusが"contracted"に変更されるか' do
         skip '未実装のため後日実装'
       end

--- a/spec/models/parking_space_spec.rb
+++ b/spec/models/parking_space_spec.rb
@@ -37,6 +37,8 @@ RSpec.describe ParkingSpace, type: :model do
       end
 
       it 'lengthが9.9だった場合' do
+        parking_space.length = 9.9
+        expect(parking_space).to be_valid
       end
 
       it 'priceが0だった場合' do

--- a/spec/models/parking_space_spec.rb
+++ b/spec/models/parking_space_spec.rb
@@ -66,6 +66,8 @@ RSpec.describe ParkingSpace, type: :model do
       end
 
       it 'desctiptionが151文字以上だった場合' do
+        parking_space.description = 'あ' * 151
+        expect(parking_space).to be_invalid
       end
 
       it 'widthが-1だった場合' do

--- a/spec/models/parking_spece_spec.rb
+++ b/spec/models/parking_spece_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ParkingSpece, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/parking_spece_spec.rb
+++ b/spec/models/parking_spece_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe ParkingSpece, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end


### PR DESCRIPTION
closes #301 
# 概要
RSpec/parking_spaceのModelテストの実装

# 内容
RSpec・FactoryBotを使用してのテストコードの実装しました。

## テスト条件: create
- [ ] バリデーション：成功
- 設定した全てのバリデーションが機能しているか
- nameが10文字だった場合
- descriptionが150文字だった場合
- widthが0だった場合
- widthが9.9だった場合
- lengthが0だった場合
- lengthが9.9だった場合
- priceが0だった場合
- priceが空欄だった場合

- [ ] バリデーション：失敗
- nameが11文字だった場合
- nameが既に登録されていた場合
- nameが空欄だった場合
- desctiptionが151文字以上だった場合
- widthが-1だった場合
- widthが10だった場合
- widthが文字列だった場合
- widthが空欄だった場合
- lengthが-1だった場合
- lengthが10だった場合
- lengthが文字列だった場合
- lengthが空欄だった場合
- priceが負の数値だった場合
- priceが小数だった場合
- parking_areaが紐づいていなかった場合

## テスト条件: update
### parking_spaceが契約履歴がない場合
- [ ] バリデーション：成功
- nameが変更することができる

- [ ] バリデーション：失敗
- 作成されたスペースのpriceを空欄にした場合

### parking_spaceが契約履歴がある場合
- [ ] バリデーション：失敗
- nameの変更を無効になる

## テスト条件: アソシエーション
### parking_spaceが契約履歴がある場合
- parking_spaceを削除されずに残る