### PR TITLE
Feature/parking space status on contract

### DIFF
--- a/app/models/contract_parking_space.rb
+++ b/app/models/contract_parking_space.rb
@@ -14,6 +14,9 @@ class ContractParkingSpace < ApplicationRecord
   delegate :parking_area, to: :parking_space
   delegate :parking_lot, to: :parking_area
 
+  after_save :sync_parking_space_status
+  after_destroy :sync_parking_space_status
+
   # 有効な契約
   scope :active, -> {
     today = Date.current
@@ -43,5 +46,20 @@ class ContractParkingSpace < ApplicationRecord
 
   def parking_area
     parking_space&.parking_area
+  end
+
+  private
+
+  # 契約状況によってparking_space.statusを同期
+  def sync_parking_space_status
+    return if parking_space.status_prohibited?
+
+    new_status =
+      if parking_space.contract_parking_spaces.active.exists?
+        :contracted
+      else
+        :available
+      end
+    parking_space.update!(status: new_status) unless parking_space.status == new_status.to_s
   end
 end

--- a/spec/models/parking_space_spec.rb
+++ b/spec/models/parking_space_spec.rb
@@ -166,7 +166,15 @@ RSpec.describe ParkingSpace, type: :model do
           parking_space.name = '2'
           expect(parking_space).to be_invalid
         end
+
         it 'parking_spaceが現在契約時、契約終了するとstatusが"available"に変更されるか' do
+          parking_space = create(:parking_space, status: 'contracted', parking_area: parking_area)
+          contract = create(:contract_parking_space, parking_space: parking_space)
+          expect(parking_space.reload.status).to eq 'contracted'
+          contract.update(end_date: Date.yesterday)
+
+          expect(parking_space.reload.status).to eq 'available'
+        end
       end
     end
   end

--- a/spec/models/parking_space_spec.rb
+++ b/spec/models/parking_space_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe ParkingSpace, type: :model do
-    let(:parking_area) { FactoryBot.create(:parking_area) }
-    let(:parking_space) { FactoryBot.build(:parking_space) }
+  let(:parking_area) { FactoryBot.create(:parking_area) }
+  let(:parking_space) { FactoryBot.build(:parking_space) }
 
   describe 'create' do
     # 成功パターン
@@ -145,13 +145,14 @@ RSpec.describe ParkingSpace, type: :model do
         it '契約時、statusが"contracted"に変更されるか' do
           parking_space = create(:parking_space, status: 'available', parking_area: parking_area)
           create(:contract_parking_space, parking_space: parking_space)
-          
+
           expect(parking_space.reload.status).to eq 'contracted'
         end
       end
-      context 'parking_spaceが現在契約している場合'
+
+      context 'parking_spaceが現在契約している場合' do
         it '契約終了するとstatusが"available"に変更されるか' do
-          parking_space = create(:parking_space, status: 'contracted', parking_area: parking_area)
+          parking_space = create(:parking_space, status: 'available', parking_area: parking_area)
           contract = create(:contract_parking_space, parking_space: parking_space)
           expect(parking_space.reload.status).to eq 'contracted'
           contract.update(end_date: Date.yesterday)
@@ -160,6 +161,12 @@ RSpec.describe ParkingSpace, type: :model do
         end
 
         it '即日契約終了するとき、今日までは契約しておりstatusは"contracted"であるか' do
+          parking_space = create(:parking_space, status: 'available', parking_area: parking_area)
+          contract = create(:contract_parking_space, parking_space: parking_space)
+          expect(parking_space.reload.status).to eq 'contracted'
+
+          contract.update(end_date: Date.current)
+          expect(parking_space.reload.status).to eq 'contracted'
         end
       end
     end
@@ -189,7 +196,7 @@ RSpec.describe ParkingSpace, type: :model do
         parking_space = create(:parking_space, parking_area: parking_area)
         create(:contract_parking_space, parking_space: parking_space)
         expect { parking_space.destroy }.to raise_error(ActiveRecord::DeleteRestrictionError)
-         expect(ParkingSpace.exists?(parking_space.id)).to be true
+        expect(ParkingSpace.exists?(parking_space.id)).to be true
       end
     end
   end

--- a/spec/models/parking_space_spec.rb
+++ b/spec/models/parking_space_spec.rb
@@ -166,6 +166,7 @@ RSpec.describe ParkingSpace, type: :model do
           parking_space.name = '2'
           expect(parking_space).to be_invalid
         end
+        it 'parking_spaceが現在契約時、契約終了するとstatusが"available"に変更されるか' do
       end
     end
   end

--- a/spec/models/parking_space_spec.rb
+++ b/spec/models/parking_space_spec.rb
@@ -141,6 +141,13 @@ RSpec.describe ParkingSpace, type: :model do
           parking_space.name = '2'
           expect(parking_space).to be_valid
         end
+
+        it '契約時、statusが"contracted"に変更されるか' do
+          parking_space = create(:parking_space, status: 'available', parking_area: parking_area)
+          create(:contract_parking_space, parking_space: parking_space)
+          
+          expect(parking_space.reload.status).to eq 'contracted'
+        end
       end
     end
 
@@ -154,14 +161,10 @@ RSpec.describe ParkingSpace, type: :model do
 
       context 'parking_spaceが契約履歴がある時' do
         it 'nameの変更を無効になる' do
-          parking_space = create(:parking_space, name: '1', status: 'contracted', parking_area: parking_area)
+          parking_space = create(:parking_space, name: '1', parking_area: parking_area)
           create(:contract_parking_space, parking_space: parking_space)
           parking_space.name = '2'
           expect(parking_space).to be_invalid
-        end
-
-        it 'statusが"contracted"に変更されるか' do
-          skip '未実装のため後日実装'
         end
       end
     end

--- a/spec/models/parking_space_spec.rb
+++ b/spec/models/parking_space_spec.rb
@@ -149,6 +149,19 @@ RSpec.describe ParkingSpace, type: :model do
           expect(parking_space.reload.status).to eq 'contracted'
         end
       end
+      context 'parking_spaceが現在契約している場合'
+        it '契約終了するとstatusが"available"に変更されるか' do
+          parking_space = create(:parking_space, status: 'contracted', parking_area: parking_area)
+          contract = create(:contract_parking_space, parking_space: parking_space)
+          expect(parking_space.reload.status).to eq 'contracted'
+          contract.update(end_date: Date.yesterday)
+
+          expect(parking_space.reload.status).to eq 'available'
+        end
+
+        it '即日契約終了するとき、今日までは契約しておりstatusは"contracted"であるか' do
+        end
+      end
     end
 
     # 失敗パターン
@@ -165,15 +178,6 @@ RSpec.describe ParkingSpace, type: :model do
           create(:contract_parking_space, parking_space: parking_space)
           parking_space.name = '2'
           expect(parking_space).to be_invalid
-        end
-
-        it 'parking_spaceが現在契約時、契約終了するとstatusが"available"に変更されるか' do
-          parking_space = create(:parking_space, status: 'contracted', parking_area: parking_area)
-          contract = create(:contract_parking_space, parking_space: parking_space)
-          expect(parking_space.reload.status).to eq 'contracted'
-          contract.update(end_date: Date.yesterday)
-
-          expect(parking_space.reload.status).to eq 'available'
         end
       end
     end


### PR DESCRIPTION
closes #308 
# 概要
parking_space.statusが更新されないバグを修正

# 内容
parking_spaceが契約時に、ステータスが'available'から'contracted'に変更されていなかったので修正しました。
原因はステータス変更するロジックが抜けていたことが原因でした。
新たにロジックを実装し、それによるテストコードも実装しました。

## ロジック
- parking_spaceが契約されるとステータス'contracted'に変更
- parking_spaceが契約終了するとステータス'available'に変更

## テスト条件: update
### コールバック
- [ ] parking_spaceが契約している場合
- 契約終了するとstatusが"available"に変更されるか
- 即日契約終了するとき、今日までは契約しておりstatusは"contracted"であるか