### PR TITLE
Feature/r spec contract parking space

### DIFF
--- a/spec/models/contract_parking_space_spec.rb
+++ b/spec/models/contract_parking_space_spec.rb
@@ -32,6 +32,11 @@ RSpec.describe ContractParkingSpace, type: :model do
       end
 
       it '既にparking_spaceが契約していた場合' do
+        skip "未実装"
+        parking_space = create(:parking_space)
+        contract_parking_space_1 = create(:contract_parking_space, parking_space: parking_space)
+        contract_parking_space_2 = build(:contract_parking_space, parking_space: parking_space)
+        expect(contract_parking_space_2).to be_invalid
       end
 
       it 'parking_spaceが紐づいていない場合' do

--- a/spec/models/contract_parking_space_spec.rb
+++ b/spec/models/contract_parking_space_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe ContractParkingSpace, type: :model do
 
     # 失敗パターン
     context 'バリデーション' do
-      it 'end_dateがstart_dateよりも前だった場合' do
+      it '契約終了日が契約開始日よりも前だった場合' do
+        skip "未実装"
         contract_parking_space = build(:contract_parking_space, start_date: Date.today, end_date: Date.yesterday)
         expect(contract_parking_space).to be_invalid
       end
@@ -72,6 +73,10 @@ RSpec.describe ContractParkingSpace, type: :model do
         end
 
         it '契約終了が契約開始日よりも後の場合' do
+          skip "未実装"
+          contract_parking_space = create(:contract_parking_space, start_date: 1.month.ago.to_date)
+          contract_parking_space.end_date = 2.months.ago.to_date
+          expect(contract_parking_space).to be_invalid
         end
 
         it '契約者を変更した場合' do

--- a/spec/models/contract_parking_space_spec.rb
+++ b/spec/models/contract_parking_space_spec.rb
@@ -145,6 +145,8 @@ RSpec.describe ContractParkingSpace, type: :model do
     end
 
     it '終了日が31日以上先の場合、falseを返す' do
+contract_parking_space = create(:contract_parking_space, end_date: Date.today + 31.days)
+      expect(contract_parking_space.expiring_soon?).to be false
     end
 
     it 'end_dateが"2999/12/31"の場合、falseを返す' do

--- a/spec/models/contract_parking_space_spec.rb
+++ b/spec/models/contract_parking_space_spec.rb
@@ -32,11 +32,11 @@ RSpec.describe ContractParkingSpace, type: :model do
       end
 
       it '既にparking_spaceが契約していた場合' do
-        contract_parking_space.parking_space = nil
-        expect(contract_parking_space).to be_invalid
       end
 
       it 'parking_spaceが紐づいていない場合' do
+        contract_parking_space.parking_space = nil
+        expect(contract_parking_space).to be_invalid
       end
 
       it 'parking_managerが紐づいていない場合' do

--- a/spec/models/contract_parking_space_spec.rb
+++ b/spec/models/contract_parking_space_spec.rb
@@ -125,6 +125,12 @@ RSpec.describe ContractParkingSpace, type: :model do
         contract_parking_space = create(:contract_parking_space, created_at: Date.today.at_beginning_of_month)
         expect(ContractParkingSpace.created_this_month).to include(contract_parking_space)
       end
+
+      it '今月の最終日に作成された場合は、含まれる' do
+      end
+
+      it '今月作成されなかった場合は、含まれない' do
+      end
     end
   end
 

--- a/spec/models/contract_parking_space_spec.rb
+++ b/spec/models/contract_parking_space_spec.rb
@@ -132,6 +132,8 @@ RSpec.describe ContractParkingSpace, type: :model do
       end
 
       it '今月作成されなかった場合は、含まれない' do
+        contract_parking_space = create(:contract_parking_space, created_at: 1.month.ago)
+        expect(ContractParkingSpace.created_this_month).not_to include(contract_parking_space)
       end
     end
   end

--- a/spec/models/contract_parking_space_spec.rb
+++ b/spec/models/contract_parking_space_spec.rb
@@ -55,6 +55,9 @@ RSpec.describe ContractParkingSpace, type: :model do
     # 成功パターン
     context 'バリデーション' do
       it 'end_dateを今日に設定できるか' do
+        contract_parking_space = create(:contract_parking_space)
+        contract_parking_space.end_date = Date.today
+        expect(contract_parking_space).to be_valid
       end
     end
 

--- a/spec/models/contract_parking_space_spec.rb
+++ b/spec/models/contract_parking_space_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ContractParkingSpace, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/contract_parking_space_spec.rb
+++ b/spec/models/contract_parking_space_spec.rb
@@ -102,6 +102,8 @@ RSpec.describe ContractParkingSpace, type: :model do
       end
 
       it '契約期間外（終了済み)の場合は、含まない' do
+        contract_parking_space = create(:contract_parking_space, start_date: 1.month.ago.to_date, end_date: Date.yesterday)
+        expect(ContractParkingSpace.active).not_to include(contract_parking_space)
       end
 
       it 'end_dateがnilで開始日が過去の場合、含まれる' do

--- a/spec/models/contract_parking_space_spec.rb
+++ b/spec/models/contract_parking_space_spec.rb
@@ -138,8 +138,10 @@ RSpec.describe ContractParkingSpace, type: :model do
     end
   end
 
-  describe '#expirigng_soon?' do
+  describe '#expiring_soon?' do
     it '終了日が30日以内の場合は、trueを返す' do
+      contract_parking_space = create(:contract_parking_space, end_date: Date.today + 30.days)
+      expect(contract_parking_space.expiring_soon?).to be true
     end
 
     it '終了日が31日以上先の場合、falseを返す' do

--- a/spec/models/contract_parking_space_spec.rb
+++ b/spec/models/contract_parking_space_spec.rb
@@ -13,12 +13,17 @@ RSpec.describe ContractParkingSpace, type: :model do
       end
 
       it 'end_dateが空欄の時、"2999/12/31"になるか' do
+        skip "実装予定"
+        contract_parking_space.end_date = nil
+        expect(contract_parking_space).to eq '2999/12/31'
       end
     end
 
     # 失敗パターン
     context 'バリデーション' do
       it 'end_dateがstert_dateよりも前だった場合' do
+        contract_parking_space = build(:contract_parking_space, start_date: Date.today, end_date: Date.yesterday)
+        expect(contract_parking_space).to be_invalid
       end
 
       it 'contractorが紐づいていない場合' do

--- a/spec/models/contract_parking_space_spec.rb
+++ b/spec/models/contract_parking_space_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe ContractParkingSpace, type: :model do
       end
 
       it 'end_dateがnilで開始日が過去の場合、含まれる' do
-        skip "end_dateがnilの場合のバリデーション未実装"
+        skip "end_dateがnilの場合default設定の未実装ため"
         contract_parking_space = create(:contract_parking_space, start_date: 1.month.ago.to_date, end_date: nil)
         expect(ContractParkingSpace.active).to include(contract_parking_space)
       end
@@ -115,6 +115,8 @@ RSpec.describe ContractParkingSpace, type: :model do
 
     describe '.terminated' do
       it '終了日が過去の場合は、含まれる' do
+        contract_parking_space = create(:contract_parking_space, start_date: 1.month.ago.to_date, end_date: Date.yesterday)
+        expect(ContractParkingSpace.terminated).to include(contract_parking_space)
       end
     end
 

--- a/spec/models/contract_parking_space_spec.rb
+++ b/spec/models/contract_parking_space_spec.rb
@@ -150,7 +150,9 @@ contract_parking_space = create(:contract_parking_space, end_date: Date.today + 
     end
 
     it 'end_dateが"2999/12/31"の場合、falseを返す' do
-    end
+ contract_parking_space = create(:contract_parking_space, end_date: "2999/12/31")
+      expect(contract_parking_space.expiring_soon?).to be false
+  end
   end
 
   describe '#expired' do

--- a/spec/models/contract_parking_space_spec.rb
+++ b/spec/models/contract_parking_space_spec.rb
@@ -107,6 +107,9 @@ RSpec.describe ContractParkingSpace, type: :model do
       end
 
       it 'end_dateがnilで開始日が過去の場合、含まれる' do
+        skip "end_dateがnilの場合のバリデーション未実装"
+        contract_parking_space = create(:contract_parking_space, start_date: 1.month.ago.to_date, end_date: nil)
+        expect(ContractParkingSpace.active).to include(contract_parking_space)
       end
     end
 

--- a/spec/models/contract_parking_space_spec.rb
+++ b/spec/models/contract_parking_space_spec.rb
@@ -32,6 +32,8 @@ RSpec.describe ContractParkingSpace, type: :model do
       end
 
       it '既にparking_spaceが契約していた場合' do
+        contract_parking_space.parking_space = nil
+        expect(contract_parking_space).to be_invalid
       end
 
       it 'parking_spaceが紐づいていない場合' do

--- a/spec/models/contract_parking_space_spec.rb
+++ b/spec/models/contract_parking_space_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe ContractParkingSpace, type: :model do
 
     # 失敗パターン
     context 'バリデーション' do
-      it 'end_dateがstert_dateよりも前だった場合' do
+      it 'end_dateがstart_dateよりも前だった場合' do
         contract_parking_space = build(:contract_parking_space, start_date: Date.today, end_date: Date.yesterday)
         expect(contract_parking_space).to be_invalid
       end

--- a/spec/models/contract_parking_space_spec.rb
+++ b/spec/models/contract_parking_space_spec.rb
@@ -155,8 +155,10 @@ contract_parking_space = create(:contract_parking_space, end_date: Date.today + 
   end
   end
 
-  describe '#expired' do
+  describe '#expired?' do
     it '終了日が過去の場合、trueを返す' do
+      contract_parking_space = create(:contract_parking_space, start_date: 2.months.ago, end_date: Date.yesterday)
+      expect(contract_parking_space.expired?).to be true
     end
 
     it '終了日が未来の場合、falseを返す' do

--- a/spec/models/contract_parking_space_spec.rb
+++ b/spec/models/contract_parking_space_spec.rb
@@ -76,12 +76,19 @@ RSpec.describe ContractParkingSpace, type: :model do
           contractor_1 = create(:contractor)
           contractor_2 = create(:contractor)
           contract_parking_space = create(:contract_parking_space, contractor: contractor_1)
-          contract_parking_space.contractor = contractor_2
 
+          contract_parking_space.contractor = contractor_2
           expect(contract_parking_space).to be_invalid
         end
 
         it '駐車スペースを変更した場合' do
+          skip "未実装"
+          parking_space_1 = create(:parking_space)
+          parking_space_2 = create(:parking_space)
+          contract_parking_space = create(:contract_parking_space, parking_space: parking_space_1)
+
+          contract_parking_space.parking_space = parking_space_2
+          expect(contract_parking_space).to be_invalid
         end
       end
     end

--- a/spec/models/contract_parking_space_spec.rb
+++ b/spec/models/contract_parking_space_spec.rb
@@ -127,6 +127,8 @@ RSpec.describe ContractParkingSpace, type: :model do
       end
 
       it '今月の最終日に作成された場合は、含まれる' do
+        contract_parking_space = create(:contract_parking_space, created_at: Date.today.at_end_of_month)
+        expect(ContractParkingSpace.created_this_month).to include(contract_parking_space)
       end
 
       it '今月作成されなかった場合は、含まれない' do

--- a/spec/models/contract_parking_space_spec.rb
+++ b/spec/models/contract_parking_space_spec.rb
@@ -121,7 +121,9 @@ RSpec.describe ContractParkingSpace, type: :model do
     end
 
     describe '.created_this_month' do
-      it '今月の1日作成された場合は、含まれる' do
+      it '今月の1日に作成された場合は、含まれる' do
+        contract_parking_space = create(:contract_parking_space, created_at: Date.today.at_beginning_of_month)
+        expect(ContractParkingSpace.created_this_month).to include(contract_parking_space)
       end
     end
   end

--- a/spec/models/contract_parking_space_spec.rb
+++ b/spec/models/contract_parking_space_spec.rb
@@ -27,6 +27,8 @@ RSpec.describe ContractParkingSpace, type: :model do
       end
 
       it 'contractorが紐づいていない場合' do
+        contract_parking_space.contractor = nil
+        expect(contract_parking_space).to be_invalid
       end
 
       it '既にparking_spaceが契約していた場合' do

--- a/spec/models/contract_parking_space_spec.rb
+++ b/spec/models/contract_parking_space_spec.rb
@@ -157,11 +157,13 @@ contract_parking_space = create(:contract_parking_space, end_date: Date.today + 
 
   describe '#expired?' do
     it '終了日が過去の場合、trueを返す' do
-      contract_parking_space = create(:contract_parking_space, start_date: 2.months.ago, end_date: Date.yesterday)
+      contract_parking_space = create(:contract_parking_space, start_date: 1.month.ago, end_date: Date.yesterday)
       expect(contract_parking_space.expired?).to be true
     end
 
     it '終了日が未来の場合、falseを返す' do
+      contract_parking_space = create(:contract_parking_space, end_date: Date.tomorrow)
+      expect(contract_parking_space.expired?).to be false
     end
   end
 end

--- a/spec/models/contract_parking_space_spec.rb
+++ b/spec/models/contract_parking_space_spec.rb
@@ -45,6 +45,8 @@ RSpec.describe ContractParkingSpace, type: :model do
       end
 
       it 'parking_managerが紐づいていない場合' do
+        contract_parking_space.parking_manager = nil
+        expect(contract_parking_space).to be_invalid
       end
     end
   end

--- a/spec/models/contract_parking_space_spec.rb
+++ b/spec/models/contract_parking_space_spec.rb
@@ -97,6 +97,8 @@ RSpec.describe ContractParkingSpace, type: :model do
   describe 'スコープ' do
     describe '.active' do
       it '契約期間内の場合は、含まれる' do
+        contract_parking_space = create(:contract_parking_space, start_date: 1.month.ago.to_date, end_date: Date.today)
+        expect(ContractParkingSpace.active).to include(contract_parking_space)
       end
 
       it '契約期間外（終了済み)の場合は、含まない' do

--- a/spec/models/contract_parking_space_spec.rb
+++ b/spec/models/contract_parking_space_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe ContractParkingSpace, type: :model do
     end
 
     describe '.created_this_month' do
-      it '今月作成された場合は、含まれる' do
+      it '今月の1日作成された場合は、含まれる' do
       end
     end
   end

--- a/spec/models/contract_parking_space_spec.rb
+++ b/spec/models/contract_parking_space_spec.rb
@@ -71,6 +71,9 @@ RSpec.describe ContractParkingSpace, type: :model do
           expect(contract_parking_space).to be_invalid
         end
 
+        it '契約終了が契約開始日よりも後の場合' do
+        end
+
         it '契約者を変更した場合' do
           skip "未実装"
           contractor_1 = create(:contractor)

--- a/spec/models/contract_parking_space_spec.rb
+++ b/spec/models/contract_parking_space_spec.rb
@@ -3,11 +3,13 @@ require 'rails_helper'
 RSpec.describe ContractParkingSpace, type: :model do
   let(:parking_space) { FactoryBot.create(:parking_space) }
   let(:contractor) { FactoryBot.create(:contractor) }
+  let(:contract_parking_space) { FactoryBot.build(:contract_parking_space) }
 
   describe 'create' do
     # 成功パターン
     context 'バリデーション' do
       it '設定した全てのバリデーションが機能しているか' do
+        expect(contract_parking_space).to be_valid
       end
 
       it 'end_dateが空欄の時、"2999/12/31"になるか' do

--- a/spec/models/contract_parking_space_spec.rb
+++ b/spec/models/contract_parking_space_spec.rb
@@ -1,5 +1,97 @@
 require 'rails_helper'
 
 RSpec.describe ContractParkingSpace, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:parking_space) { FactoryBot.create(:parking_space) }
+  let(:contractor) { FactoryBot.create(:contractor) }
+
+  describe 'create' do
+    # 成功パターン
+    context 'バリデーション' do
+      it '設定した全てのバリデーションが機能しているか' do
+      end
+
+      it 'end_dateが空欄の時、"2999/12/31"になるか' do
+      end
+    end
+
+    # 失敗パターン
+    context 'バリデーション' do
+      it 'end_dateがstert_dateよりも前だった場合' do
+      end
+
+      it 'contractorが紐づいていない場合' do
+      end
+
+      it '既にparking_spaceが契約していた場合' do
+      end
+
+      it 'parking_spaceが紐づいていない場合' do
+      end
+
+      it 'parking_managerが紐づいていない場合' do
+      end
+    end
+  end
+
+  describe 'update' do
+    # 成功パターン
+    context 'バリデーション' do
+      it 'end_dateを今日に設定できるか' do
+      end
+    end
+
+    # 失敗パターン
+    context 'バリデーション' do
+      it 'start_dateを変更した場合' do
+      end
+
+      it '契約者を変更した場合' do
+      end
+
+      it '駐車スペースを変更した場合' do
+      end
+    end
+  end
+
+  describe 'スコープ' do
+    describe '.active' do
+      it '契約期間内の場合は、含まれる' do
+      end
+
+      it '契約期間外（終了済み)の場合は、含まない' do
+      end
+
+      it 'end_dateがnilで開始日が過去の場合、含まれる' do
+      end
+    end
+
+    describe '.terminated' do
+      it '終了日が過去の場合は、含まれる' do
+      end
+    end
+
+    describe '.created_this_month' do
+      it '今月作成された場合は、含まれる' do
+      end
+    end
+  end
+
+  describe '#expirigng_soon?' do
+    it '終了日が30日以内の場合は、trueを返す' do
+    end
+
+    it '終了日が31日以上先の場合、falseを返す' do
+    end
+
+    it 'end_dateが"2999/12/31"の場合、falseを返す' do
+    end
+  end
+
+  describe '#expired' do
+    it '終了日が過去の場合、trueを返す' do
+    end
+
+    it '終了日が未来の場合、falseを返す' do
+    end
+  end
 end

--- a/spec/models/contract_parking_space_spec.rb
+++ b/spec/models/contract_parking_space_spec.rb
@@ -63,13 +63,19 @@ RSpec.describe ContractParkingSpace, type: :model do
 
     # 失敗パターン
     context 'バリデーション' do
-      it 'start_dateを変更した場合' do
-      end
+      context '契約が有効な場合' do
+        it 'start_dateを変更した場合' do
+          skip "未実装"
+          contract_parking_space = create(:contract_parking_space, start_date: 1.month.ago.to_date)
+          contract_parking_space.start_date = Date.today
+          expect(contract_parking_space).to be_invalid
+        end
 
-      it '契約者を変更した場合' do
-      end
+        it '契約者を変更した場合' do
+        end
 
-      it '駐車スペースを変更した場合' do
+        it '駐車スペースを変更した場合' do
+        end
       end
     end
   end

--- a/spec/models/contract_parking_space_spec.rb
+++ b/spec/models/contract_parking_space_spec.rb
@@ -72,6 +72,13 @@ RSpec.describe ContractParkingSpace, type: :model do
         end
 
         it '契約者を変更した場合' do
+          skip "未実装"
+          contractor_1 = create(:contractor)
+          contractor_2 = create(:contractor)
+          contract_parking_space = create(:contract_parking_space, contractor: contractor_1)
+          contract_parking_space.contractor = contractor_2
+
+          expect(contract_parking_space).to be_invalid
         end
 
         it '駐車スペースを変更した場合' do

--- a/spec/models/contract_parking_space_spec.rb
+++ b/spec/models/contract_parking_space_spec.rb
@@ -54,8 +54,8 @@ RSpec.describe ContractParkingSpace, type: :model do
   describe 'update' do
     # 成功パターン
     context 'バリデーション' do
-      it 'end_dateを今日に設定できるか' do
-        contract_parking_space = create(:contract_parking_space)
+      it 'end_dateを今日に変更できるか' do
+        contract_parking_space = create(:contract_parking_space, end_date: 2.months.from_now)
         contract_parking_space.end_date = Date.today
         expect(contract_parking_space).to be_valid
       end


### PR DESCRIPTION
closes #287 
# 概要
ContractParkingSpaceのModelテストコードを実装

# 内容
RSpec・FactoryBotを使用しての駐車場契約”ContractParkingSpace”のModelテストを実装しました。
テストにより未実装のバリデーションが多く発見したので次の実装で修正します。

## テスト条件: バリデーション
- [ ] 成功
- 設定した全てのバリデーションが機能しているか
- end_dateが空欄の時、"2999/12/31"になるか(未実装)

- [ ] 失敗
- end_dateがstart_dateよりも前だった場合
- contractorが紐づいていない場合
- 既にparking_spaceが契約していた場合(未実装)
- parking_spaceが紐づいていない場合
- parking_managerが紐づいていない場合

## テスト条件：update
- [ ] 成功
- end_dateを今日に変更できるか

### 契約が有効な場合
- [ ] 失敗
- start_dateを変更した場合(未実装)
- 契約終了が契約開始日よりも後の場合(未実装)
- 契約者を変更した場合(未実装)
- 駐車スペースを変更した場合(未実装)

## テスト条件： スコープ
- [ ] active
- 契約期間内の場合は、含まれる
- 契約期間外（終了済み)の場合は、含まない
- end_dateがnilで開始日が過去の場合、含まれる

- [ ] terminated
- 終了日が過去の場合は、含まれる

- [ ] created_this_month
- 今月の1日に作成された場合は、含まれる
- 今月の最終日に作成された場合は、含まれる
- 今月作成されなかった場合は、含まれない

## テスト条件：メソッド
- [ ] expiring_soon?
- 終了日が30日以内の場合は、trueを返す
- 終了日が31日以上先の場合、falseを返す
- end_dateが"2999/12/31"の場合、falseを返す

- [ ] expired?
- 終了日が過去の場合、trueを返す
- 終了日が未来の場合、falseを返す