### PR TITLE
01 update contract parking space validates

### DIFF
--- a/app/controllers/contract_parking_spaces_controller.rb
+++ b/app/controllers/contract_parking_spaces_controller.rb
@@ -65,7 +65,7 @@ class ContractParkingSpacesController < ApplicationController
 
   def contract_params
     params.require(:contract_parking_space).permit(
-      :start_date, :end_date, :contractor_id, :parking_space_id
+      :start_date, :end_date, :contractor_id, :parking_space_id, :end_date_undetermined
     )
   end
 

--- a/app/models/contract_parking_space.rb
+++ b/app/models/contract_parking_space.rb
@@ -1,4 +1,6 @@
 class ContractParkingSpace < ApplicationRecord
+  before_validation :undetermined
+
   validates :start_date, presence: true
   validates :end_date, presence: true
   validates :contractor, presence: true
@@ -15,13 +17,14 @@ class ContractParkingSpace < ApplicationRecord
   delegate :parking_lot, to: :parking_area
 
   after_save :sync_parking_space_status
+
   after_destroy :sync_parking_space_status
 
   # 有効な契約
   scope :active, -> {
     today = Date.current
     where("start_date <= :today AND (end_date >= :today OR end_date IS NULL)", today: today)
-    }
+  }
 
   # 今月に新たに作成されたデータ
   scope :created_this_month, -> {
@@ -61,5 +64,11 @@ class ContractParkingSpace < ApplicationRecord
         :available
       end
     parking_space.update!(status: new_status) unless parking_space.status == new_status.to_s
+  end
+
+  def undetermined
+    if end_date_undetermined?
+      self.end_date = '2999-12-31'
+    end
   end
 end

--- a/app/models/contract_parking_space.rb
+++ b/app/models/contract_parking_space.rb
@@ -73,10 +73,10 @@ class ContractParkingSpace < ApplicationRecord
   end
 
   def undetermined
-    if end_date.present? && end_date.to_s != '2999-12-31'
+    if end_date.present? && end_date.to_s != "2999-12-31"
       self.end_date_undetermined = false
     elsif end_date_undetermined?
-      self.end_date = '2999-12-31'
+      self.end_date = "2999-12-31"
     end
   end
 

--- a/app/models/contract_parking_space.rb
+++ b/app/models/contract_parking_space.rb
@@ -8,6 +8,7 @@ class ContractParkingSpace < ApplicationRecord
   validates :parking_manager, presence: true
 
   validate :end_date_after_start_date
+  validate :parking_space_available
 
   belongs_to :contractor
   belongs_to :parking_space
@@ -80,6 +81,13 @@ class ContractParkingSpace < ApplicationRecord
     return if end_date.blank? || start_date.blank?
     if end_date < start_date
       errors.add(:end_date, "は契約開始日より前ですので設定できません。")
+    end
+  end
+
+  def parking_space_available
+    return if parking_space.blank?
+    if parking_space.contract_parking_spaces.active.where.not(id: id).exists?
+      errors.add(:parking_space, "はすでに契約されています。")
     end
   end
 end

--- a/app/models/contract_parking_space.rb
+++ b/app/models/contract_parking_space.rb
@@ -67,8 +67,11 @@ class ContractParkingSpace < ApplicationRecord
   end
 
   def undetermined
-    if end_date_undetermined?
-      self.end_date = '2999-12-31'
+    if end_date.present? && end_date.to_s != '2999-12-31'
+      self.end_date_undetermined = false
+    elsif end_date_undetermined?
+      end_date.present?
+      self.end_date_undetermined = '2999-12-31'
     end
   end
 end

--- a/app/models/contract_parking_space.rb
+++ b/app/models/contract_parking_space.rb
@@ -9,6 +9,8 @@ class ContractParkingSpace < ApplicationRecord
 
   validate :end_date_after_start_date
   validate :parking_space_available
+  validate :start_date_immutable_if_active, on: :update
+  validate :contractor_immutable_if_active, on: :update
 
   belongs_to :contractor
   belongs_to :parking_space
@@ -89,5 +91,17 @@ class ContractParkingSpace < ApplicationRecord
     if parking_space.contract_parking_spaces.active.where.not(id: id).exists?
       errors.add(:parking_space, "はすでに契約されています。")
     end
+  end
+
+  def start_date_immutable_if_active
+    return unless ContractParkingSpace.active.exists?(id)
+    return unless start_date_changed?
+    errors.add(:start_date, "契約が有効のため変更できません。")
+  end
+
+  def contractor_immutable_if_active
+    return unless ContractParkingSpace.active.exists?(id)
+    return unless contractor_changed?
+    errors.add(:contractor, "契約が有効のため変更できません。")
   end
 end

--- a/app/models/contract_parking_space.rb
+++ b/app/models/contract_parking_space.rb
@@ -11,6 +11,7 @@ class ContractParkingSpace < ApplicationRecord
   validate :parking_space_available
   validate :start_date_immutable_if_active, on: :update
   validate :contractor_immutable_if_active, on: :update
+  validate :parking_space_immutable_if_active, on: :update
 
   belongs_to :contractor
   belongs_to :parking_space
@@ -103,5 +104,11 @@ class ContractParkingSpace < ApplicationRecord
     return unless ContractParkingSpace.active.exists?(id)
     return unless contractor_changed?
     errors.add(:contractor, "契約が有効のため変更できません。")
+  end
+
+  def parking_space_immutable_if_active
+    return unless ContractParkingSpace.active.exists?(id)
+    return unless parking_space_changed?
+    errors.add(:parking_space, "契約が有効のため変更できません。")
   end
 end

--- a/app/models/contract_parking_space.rb
+++ b/app/models/contract_parking_space.rb
@@ -7,6 +7,8 @@ class ContractParkingSpace < ApplicationRecord
   validates :parking_space, presence: true
   validates :parking_manager, presence: true
 
+  validate :end_date_after_start_date
+
   belongs_to :contractor
   belongs_to :parking_space
   belongs_to :parking_manager
@@ -70,8 +72,14 @@ class ContractParkingSpace < ApplicationRecord
     if end_date.present? && end_date.to_s != '2999-12-31'
       self.end_date_undetermined = false
     elsif end_date_undetermined?
-      end_date.present?
-      self.end_date_undetermined = '2999-12-31'
+      self.end_date = '2999-12-31'
+    end
+  end
+
+  def end_date_after_start_date
+    return if end_date.blank? || start_date.blank?
+    if end_date < start_date
+      errors.add(:end_date, "は契約開始日より前ですので設定できません。")
     end
   end
 end

--- a/app/views/contract_parking_spaces/edit.html.erb
+++ b/app/views/contract_parking_spaces/edit.html.erb
@@ -11,6 +11,8 @@
         <% end %>
       </div>
 
+      <%= render "shared/error_messages", object: @contract_parking_space %>
+
       <div class="p-6">
         <div class="mb-6 p-4 bg-indigo-50 rounded-lg border border-indigo-100 flex items-center justify-between">
           <div>

--- a/app/views/contract_parking_spaces/edit.html.erb
+++ b/app/views/contract_parking_spaces/edit.html.erb
@@ -43,7 +43,7 @@
 
           <div>
             <%= f.label :end_date, "契約終了日", class: "block text-sm font-medium text-gray-700" %>
-            <%= f.date_field :end_date, id: "end_date_field",
+            <%= f.date_field :end_date, id: "end_date_field", value: '',
                 class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" %>
           </div>
 

--- a/app/views/contract_parking_spaces/new.html.erb
+++ b/app/views/contract_parking_spaces/new.html.erb
@@ -73,7 +73,7 @@
               </div>
               <div>
                 <%= f.label :end_date, "契約終了日", class: "block text-sm font-medium text-gray-700" %>
-                <%= f.date_field :end_date, value: '2999-12-31', class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500" %>
+                <%= f.date_field :end_date, value: '', class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500" %>
               </div>
             </div>
 

--- a/app/views/contract_parking_spaces/new.html.erb
+++ b/app/views/contract_parking_spaces/new.html.erb
@@ -7,10 +7,13 @@
           <i class="fa-solid fa-file-contract mr-2 text-blue-600"></i>
           新規契約作成：<%= @contractor.full_name %> 様
         </h3>
+
         <%= link_to contractor_path(@contractor), data: { turbo_frame: "_top" }, class: "text-gray-400 hover:text-gray-600" do %>
           <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" /></svg>
         <% end %>
       </div>
+
+      <%= render "shared/error_messages", object: @contract_parking_space %>
 
       <div class="p-6 space-y-6">
         <%# ステップ1 & 2：駐車場とエリアの選択（これらはGETメソッドで自分自身をリロード） %>

--- a/app/views/contract_parking_spaces/new.html.erb
+++ b/app/views/contract_parking_spaces/new.html.erb
@@ -15,74 +15,79 @@
       <div class="p-6 space-y-6">
         <%# ステップ1 & 2：駐車場とエリアの選択（これらはGETメソッドで自分自身をリロード） %>
         <%= form_with url: new_contractor_contract_parking_space_path(@contractor), 
-                      method: :get, 
-                      data: { turbo_frame: "modal" },
-                      class: "space-y-4" do |f| %>
-          
-          <div class="bg-blue-50 p-4 rounded-lg border border-blue-100 space-y-4">
-            <div>
-              <%= f.label :parking_lot_id, "ステップ1：駐車場を選択", class: "block text-sm font-bold text-blue-900 mb-2" %>
-              <%= f.collection_select :parking_lot_id, @parking_lots, :id, :name, 
-                  { selected: params[:parking_lot_id] }, 
-                  { class: "block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500", 
-                    onchange: "this.form.requestSubmit()" } %>
-            </div>
+        method: :get, 
+        data: { turbo_frame: "modal" },
+        class: "space-y-4" do |f| %>
 
-            <% if @parking_lot %>
-              <div>
-                <%= f.label :parking_area_id, "ステップ2：エリアを選択", class: "block text-sm font-bold text-blue-900 mb-2" %>
-                <%= f.collection_select :parking_area_id, @parking_lot.parking_areas, :id, :name, 
-                    { selected: params[:parking_area_id], prompt: "エリアを選択してください" }, 
-                    { class: "block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500", 
-                      onchange: "this.form.requestSubmit()" } %>
+        <div class="bg-blue-50 p-4 rounded-lg border border-blue-100 space-y-4">
+          <div>
+            <%= f.label :parking_lot_id, "ステップ1：駐車場を選択", class: "block text-sm font-bold text-blue-900 mb-2" %>
+            <%= f.collection_select :parking_lot_id, @parking_lots, :id, :name, 
+              { selected: params[:parking_lot_id] }, 
+              { class: "block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500", 
+                onchange: "this.form.requestSubmit()" } %>
+          </div>
+
+          <% if @parking_lot %>
+            <div>
+              <%= f.label :parking_area_id, "ステップ2：エリアを選択", class: "block text-sm font-bold text-blue-900 mb-2" %>
+              <%= f.collection_select :parking_area_id, @parking_lot.parking_areas, :id, :name, 
+                { selected: params[:parking_area_id], prompt: "エリアを選択してください" }, 
+                { class: "block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500", 
+                  onchange: "this.form.requestSubmit()" } %>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
+
+      <hr class="border-gray-100">
+
+      <div id="parking_form_area">
+        <%= form_with(model: [@contractor, @contract_parking_space], class: "space-y-6") do |f| %>
+          <%# 選択状態を維持するための隠しフィールド %>
+          <%= hidden_field_tag :parking_lot_id, params[:parking_lot_id] %>
+          <%= hidden_field_tag :parking_area_id, params[:parking_area_id] %>
+
+          <div>
+            <%= f.label :parking_space_id, "ステップ3：駐車区画を選択してください", class: "block text-sm font-medium text-gray-700 mb-1" %>
+
+            <% if @parking_area %>
+              <%= f.collection_select :parking_space_id, @parking_area.parking_spaces.available, :id, :name, 
+                { prompt: "区画を選択..." }, 
+                { class: "block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500", required: true } %>
+
+              <% if @parking_area.parking_spaces.available.empty? %>
+                <p class="mt-2 text-sm text-red-500"><i class="fa-solid fa-triangle-exclamation mr-1"></i> このエリアに空き区画はありません。</p>
+              <% end %>
+            <% else %>
+              <div class="p-3 bg-gray-50 border border-dashed border-gray-300 rounded text-sm text-gray-500 text-center">
+                エリアを選択すると区画が表示されます
               </div>
             <% end %>
           </div>
-        <% end %>
 
-        <hr class="border-gray-100">
-
-        <div id="parking_form_area">
-          <%= form_with(model: [@contractor, @contract_parking_space], class: "space-y-6") do |f| %>
-            <%# 選択状態を維持するための隠しフィールド %>
-            <%= hidden_field_tag :parking_lot_id, params[:parking_lot_id] %>
-            <%= hidden_field_tag :parking_area_id, params[:parking_area_id] %>
-
+          <div class="grid grid-cols-2 gap-4 pt-2">
             <div>
-              <%= f.label :parking_space_id, "ステップ3：駐車区画を選択してください", class: "block text-sm font-medium text-gray-700 mb-1" %>
-              
-              <% if @parking_area %>
-                <%= f.collection_select :parking_space_id, @parking_area.parking_spaces.available, :id, :name, 
-                    { prompt: "区画を選択..." }, 
-                    { class: "block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500", required: true } %>
-
-                <% if @parking_area.parking_spaces.available.empty? %>
-                  <p class="mt-2 text-sm text-red-500"><i class="fa-solid fa-triangle-exclamation mr-1"></i> このエリアに空き区画はありません。</p>
-                <% end %>
-              <% else %>
-                <div class="p-3 bg-gray-50 border border-dashed border-gray-300 rounded text-sm text-gray-500 text-center">
-                  エリアを選択すると区画が表示されます
-                </div>
-              <% end %>
+              <%= f.label :start_date, "契約開始日", class: "block text-sm font-medium text-gray-700" %>
+              <%= f.date_field :start_date, value: Date.today,  class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500" %>
             </div>
-
-            <div class="grid grid-cols-2 gap-4 pt-2">
-              <div>
-                <%= f.label :start_date, "契約開始日", class: "block text-sm font-medium text-gray-700" %>
-                <%= f.date_field :start_date, value: Date.today,  class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500" %>
-              </div>
-              <div>
-                <%= f.label :end_date, "契約終了日", class: "block text-sm font-medium text-gray-700" %>
-                <%= f.date_field :end_date, value: '', class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500" %>
-              </div>
+            <div>
+              <%= f.label :end_date, "契約終了日", class: "block text-sm font-medium text-gray-700" %>
+              <%= f.date_field :end_date, value: '', class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500" %>
             </div>
+          </div>
 
-            <div class="pt-6 border-t border-gray-100 flex justify-end space-x-3">
-              <%= link_to "戻る", contractor_contract_parking_spaces_path(@contractor), class: "px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md shadow-sm hover:bg-gray-50" %>
-              <%= f.submit "契約を確定する", class: "px-4 py-2 text-sm font-medium text-white bg-blue-600 border border-transparent rounded-md shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500" %>
-            </div>
-          <% end %>        
-        </div>
+          <div class="flex items-center gap-2 mb-6">
+            <%= f.check_box :end_date_undetermined, class: "rounded border-gray-300 text-sky-600 focus:ring-sky-500" %>
+            <%= f.label :end_date_undetermined, "契約終了日が未定", class: "text-sm text-gray-600" %>
+          </div>
+
+          <div class="pt-6 border-t border-gray-100 flex justify-end space-x-3">
+            <%= link_to "戻る", contractor_contract_parking_spaces_path(@contractor), class: "px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md shadow-sm hover:bg-gray-50" %>
+            <%= f.submit "契約を確定する", class: "px-4 py-2 text-sm font-medium text-white bg-blue-600 border border-transparent rounded-md shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500" %>
+          </div>
+        <% end %>        
+      </div>
       </div>
 
     </div>

--- a/db/migrate/20260630070147_add_end_date_undetermined_to_contract_parking_spaces.rb
+++ b/db/migrate/20260630070147_add_end_date_undetermined_to_contract_parking_spaces.rb
@@ -1,0 +1,5 @@
+class AddEndDateUndeterminedToContractParkingSpaces < ActiveRecord::Migration[8.1]
+  def change
+    add_column :contract_parking_spaces, :end_date_undetermined, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20260630073619_remove_default_from_start_date_on_contract_parking_spaces.rb
+++ b/db/migrate/20260630073619_remove_default_from_start_date_on_contract_parking_spaces.rb
@@ -1,0 +1,5 @@
+class RemoveDefaultFromStartDateOnContractParkingSpaces < ActiveRecord::Migration[8.1]
+  def change
+    change_column_default :contract_parking_spaces, :start_date, from: "1999-12/31", to: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_30_070147) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_30_073619) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -35,7 +35,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_30_070147) do
     t.boolean "end_date_undetermined", default: false, null: false
     t.bigint "parking_manager_id", null: false
     t.bigint "parking_space_id", null: false
-    t.date "start_date", default: "1999-12-31", null: false
+    t.date "start_date", null: false
     t.datetime "updated_at", null: false
     t.index ["contractor_id"], name: "index_contract_parking_spaces_on_contractor_id"
     t.index ["parking_manager_id"], name: "index_contract_parking_spaces_on_parking_manager_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_29_043742) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_30_070147) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -32,6 +32,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_29_043742) do
     t.bigint "contractor_id", null: false
     t.datetime "created_at", null: false
     t.date "end_date", default: "2999-12-31", null: false
+    t.boolean "end_date_undetermined", default: false, null: false
     t.bigint "parking_manager_id", null: false
     t.bigint "parking_space_id", null: false
     t.date "start_date", default: "1999-12-31", null: false

--- a/spec/models/contract_parking_space_spec.rb
+++ b/spec/models/contract_parking_space_spec.rb
@@ -12,13 +12,7 @@ RSpec.describe ContractParkingSpace, type: :model do
         expect(contract_parking_space).to be_valid
       end
 
-      it '契約終了日が設定すると、end_date_undeterminedがfalseになるか' do
-        contract_parking_space = build(:contract_parking_space, end_date: 2.months.from_now)
-
-        expect(contract_parking_space.end_date_undetermined).to eq false
-      end
-
-      it '契約終了日未定をチェックすると、end_date_undeterminedがtrueになるか' do
+      it 'end_date_undeterminedがtrue、且つend_dateがnilの場合' do
       end
     end
 

--- a/spec/models/contract_parking_space_spec.rb
+++ b/spec/models/contract_parking_space_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe ContractParkingSpace, type: :model do
         expect(contract_parking_space).to be_valid
       end
 
-      it 'end_dateが空欄の時、"2999/12/31"になるか' do
+      it '契約終了日が未定チェックすると、"2999/12/31"になるか' do
         contract_parking_space.end_date = nil
         expect(contract_parking_space).to eq '2999/12/31'
       end

--- a/spec/models/contract_parking_space_spec.rb
+++ b/spec/models/contract_parking_space_spec.rb
@@ -95,6 +95,7 @@ RSpec.describe ContractParkingSpace, type: :model do
 
           contract_parking_space.contractor = contractor_2
           expect(contract_parking_space).to be_invalid
+          expect(contract_parking_space.errors[:contractor]).to eq ["契約が有効のため変更できません。"]
         end
 
         it '駐車スペースを変更した場合' do

--- a/spec/models/contract_parking_space_spec.rb
+++ b/spec/models/contract_parking_space_spec.rb
@@ -102,9 +102,9 @@ RSpec.describe ContractParkingSpace, type: :model do
           parking_space_1 = create(:parking_space)
           parking_space_2 = create(:parking_space)
           contract_parking_space = create(:contract_parking_space, parking_space: parking_space_1)
-
           contract_parking_space.parking_space = parking_space_2
           expect(contract_parking_space).to be_invalid
+          expect(contract_parking_space.errors[:parking_space]).to eq ["契約が有効のため変更できません。"]
         end
       end
     end

--- a/spec/models/contract_parking_space_spec.rb
+++ b/spec/models/contract_parking_space_spec.rb
@@ -18,6 +18,9 @@ RSpec.describe ContractParkingSpace, type: :model do
 
         expect(contract_parking_space.end_date).to eq Date.parse('2999-12-31')
       end
+
+      it 'end_date_undeterminedがtrue、且つend_dateの日付を設定した場合' do
+      end
     end
 
     # 失敗パターン

--- a/spec/models/contract_parking_space_spec.rb
+++ b/spec/models/contract_parking_space_spec.rb
@@ -20,6 +20,10 @@ RSpec.describe ContractParkingSpace, type: :model do
       end
 
       it 'end_date_undeterminedがtrue、且つend_dateの日付を設定した場合' do
+        contract_parking_space = build(:contract_parking_space, end_date: 2.months.from_now, end_date_undetermined: true)
+        contract_parking_space.valid?
+
+        expect(contract_parking_space.end_date_undetermined).to eq false
       end
     end
 
@@ -102,7 +106,7 @@ RSpec.describe ContractParkingSpace, type: :model do
 
   describe 'スコープ' do
     describe '.active' do
-      it '契約期間内の場合は、含まれる' do
+      it '契約期間が今日までの場合は、含まれる' do
         contract_parking_space = create(:contract_parking_space, start_date: 1.month.ago.to_date, end_date: Date.today)
         expect(ContractParkingSpace.active).to include(contract_parking_space)
       end
@@ -112,8 +116,8 @@ RSpec.describe ContractParkingSpace, type: :model do
         expect(ContractParkingSpace.active).not_to include(contract_parking_space)
       end
 
-      it 'end_dateがnilで開始日が過去の場合、含まれる' do
-        contract_parking_space = create(:contract_parking_space, start_date: 1.month.ago.to_date, end_date: nil)
+      it 'end_dateが未設定"2999-12-31"で開始日が過去の場合、含まれる' do
+        contract_parking_space = create(:contract_parking_space, start_date: 1.month.ago.to_date, end_date: '2999-12-31')
         expect(ContractParkingSpace.active).to include(contract_parking_space)
       end
     end

--- a/spec/models/contract_parking_space_spec.rb
+++ b/spec/models/contract_parking_space_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe ContractParkingSpace, type: :model do
       end
 
       it 'end_dateが空欄の時、"2999/12/31"になるか' do
-        skip "実装予定"
         contract_parking_space.end_date = nil
         expect(contract_parking_space).to eq '2999/12/31'
       end
@@ -22,7 +21,6 @@ RSpec.describe ContractParkingSpace, type: :model do
     # 失敗パターン
     context 'バリデーション' do
       it '契約終了日が契約開始日よりも前だった場合' do
-        skip "未実装"
         contract_parking_space = build(:contract_parking_space, start_date: Date.today, end_date: Date.yesterday)
         expect(contract_parking_space).to be_invalid
       end
@@ -33,7 +31,6 @@ RSpec.describe ContractParkingSpace, type: :model do
       end
 
       it '既にparking_spaceが契約していた場合' do
-        skip "未実装"
         parking_space = create(:parking_space)
         contract_parking_space_1 = create(:contract_parking_space, parking_space: parking_space)
         contract_parking_space_2 = build(:contract_parking_space, parking_space: parking_space)
@@ -66,21 +63,18 @@ RSpec.describe ContractParkingSpace, type: :model do
     context 'バリデーション' do
       context '契約が有効な場合' do
         it 'start_dateを変更した場合' do
-          skip "未実装"
           contract_parking_space = create(:contract_parking_space, start_date: 1.month.ago.to_date)
           contract_parking_space.start_date = Date.today
           expect(contract_parking_space).to be_invalid
         end
 
         it '契約終了が契約開始日よりも後の場合' do
-          skip "未実装"
           contract_parking_space = create(:contract_parking_space, start_date: 1.month.ago.to_date)
           contract_parking_space.end_date = 2.months.ago.to_date
           expect(contract_parking_space).to be_invalid
         end
 
         it '契約者を変更した場合' do
-          skip "未実装"
           contractor_1 = create(:contractor)
           contractor_2 = create(:contractor)
           contract_parking_space = create(:contract_parking_space, contractor: contractor_1)
@@ -90,7 +84,6 @@ RSpec.describe ContractParkingSpace, type: :model do
         end
 
         it '駐車スペースを変更した場合' do
-          skip "未実装"
           parking_space_1 = create(:parking_space)
           parking_space_2 = create(:parking_space)
           contract_parking_space = create(:contract_parking_space, parking_space: parking_space_1)
@@ -115,7 +108,6 @@ RSpec.describe ContractParkingSpace, type: :model do
       end
 
       it 'end_dateがnilで開始日が過去の場合、含まれる' do
-        skip "end_dateがnilの場合default設定の未実装ため"
         contract_parking_space = create(:contract_parking_space, start_date: 1.month.ago.to_date, end_date: nil)
         expect(ContractParkingSpace.active).to include(contract_parking_space)
       end
@@ -153,14 +145,14 @@ RSpec.describe ContractParkingSpace, type: :model do
     end
 
     it '終了日が31日以上先の場合、falseを返す' do
-contract_parking_space = create(:contract_parking_space, end_date: Date.today + 31.days)
+      contract_parking_space = create(:contract_parking_space, end_date: Date.today + 31.days)
       expect(contract_parking_space.expiring_soon?).to be false
     end
 
     it 'end_dateが"2999/12/31"の場合、falseを返す' do
- contract_parking_space = create(:contract_parking_space, end_date: "2999/12/31")
+      contract_parking_space = create(:contract_parking_space, end_date: "2999/12/31")
       expect(contract_parking_space.expiring_soon?).to be false
-  end
+    end
   end
 
   describe '#expired?' do

--- a/spec/models/contract_parking_space_spec.rb
+++ b/spec/models/contract_parking_space_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe ContractParkingSpace, type: :model do
       it '契約終了日が契約開始日よりも前だった場合' do
         contract_parking_space = build(:contract_parking_space, start_date: Date.today, end_date: Date.yesterday)
         expect(contract_parking_space).to be_invalid
-        expect(contract_parking_space.errors[:end_date]).to eq ["は契約開始日より前ですので設定できません。"]
+        expect(contract_parking_space.errors[:end_date]).to eq [ "は契約開始日より前ですので設定できません。" ]
       end
 
       it 'contractorが紐づいていない場合' do
@@ -46,7 +46,7 @@ RSpec.describe ContractParkingSpace, type: :model do
         contract_parking_space_2 = build(:contract_parking_space, parking_space: parking_space)
 
         expect(contract_parking_space_2).to be_invalid
-        expect(contract_parking_space_2.errors[:parking_space]).to eq ["はすでに契約されています。"]
+        expect(contract_parking_space_2.errors[:parking_space]).to eq [ "はすでに契約されています。" ]
       end
 
       it 'parking_spaceが紐づいていない場合' do
@@ -79,7 +79,7 @@ RSpec.describe ContractParkingSpace, type: :model do
           contract_parking_space.start_date = Date.today
 
           expect(contract_parking_space).to be_invalid
-          expect(contract_parking_space.errors[:start_date]).to eq ["契約が有効のため変更できません。"]
+          expect(contract_parking_space.errors[:start_date]).to eq [ "契約が有効のため変更できません。" ]
         end
 
         it '契約終了が契約開始日よりも後の場合' do
@@ -95,7 +95,7 @@ RSpec.describe ContractParkingSpace, type: :model do
 
           contract_parking_space.contractor = contractor_2
           expect(contract_parking_space).to be_invalid
-          expect(contract_parking_space.errors[:contractor]).to eq ["契約が有効のため変更できません。"]
+          expect(contract_parking_space.errors[:contractor]).to eq [ "契約が有効のため変更できません。" ]
         end
 
         it '駐車スペースを変更した場合' do
@@ -104,7 +104,7 @@ RSpec.describe ContractParkingSpace, type: :model do
           contract_parking_space = create(:contract_parking_space, parking_space: parking_space_1)
           contract_parking_space.parking_space = parking_space_2
           expect(contract_parking_space).to be_invalid
-          expect(contract_parking_space.errors[:parking_space]).to eq ["契約が有効のため変更できません。"]
+          expect(contract_parking_space.errors[:parking_space]).to eq [ "契約が有効のため変更できません。" ]
         end
       end
     end

--- a/spec/models/contract_parking_space_spec.rb
+++ b/spec/models/contract_parking_space_spec.rb
@@ -13,10 +13,12 @@ RSpec.describe ContractParkingSpace, type: :model do
       end
 
       it '契約終了日が設定すると、end_date_undeterminedがfalseになるか' do
-        contract_parking_space = build(:contract_parking_space, end_date: nil, end_date_undetermined: true)
-        contract_parking_space.valid?
+        contract_parking_space = build(:contract_parking_space, end_date: 2.months.from_now)
 
-        expect(contract_parking_space.end_date).to eq Date.parse('2999-12-31')
+        expect(contract_parking_space.end_date_undetermined).to eq false
+      end
+
+      it '契約終了日未定をチェックすると、end_date_undeterminedがtrueになるか' do
       end
     end
 

--- a/spec/models/contract_parking_space_spec.rb
+++ b/spec/models/contract_parking_space_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe ContractParkingSpace, type: :model do
       end
 
       it 'end_date_undeterminedがtrue、且つend_dateがnilの場合' do
+        contract_parking_space = build(:contract_parking_space, end_date: nil, end_date_undetermined: true)
+        contract_parking_space.valid?
+
+        expect(contract_parking_space.end_date).to eq Date.parse('2999-12-31')
       end
     end
 

--- a/spec/models/contract_parking_space_spec.rb
+++ b/spec/models/contract_parking_space_spec.rb
@@ -12,9 +12,11 @@ RSpec.describe ContractParkingSpace, type: :model do
         expect(contract_parking_space).to be_valid
       end
 
-      it '契約終了日が未定チェックすると、"2999/12/31"になるか' do
-        contract_parking_space.end_date = nil
-        expect(contract_parking_space).to eq '2999/12/31'
+      it '契約終了日が設定すると、end_date_undeterminedがfalseになるか' do
+        contract_parking_space = build(:contract_parking_space, end_date: nil, end_date_undetermined: true)
+        contract_parking_space.valid?
+
+        expect(contract_parking_space.end_date).to eq Date.parse('2999-12-31')
       end
     end
 

--- a/spec/models/contract_parking_space_spec.rb
+++ b/spec/models/contract_parking_space_spec.rb
@@ -44,7 +44,9 @@ RSpec.describe ContractParkingSpace, type: :model do
         parking_space = create(:parking_space)
         contract_parking_space_1 = create(:contract_parking_space, parking_space: parking_space)
         contract_parking_space_2 = build(:contract_parking_space, parking_space: parking_space)
+
         expect(contract_parking_space_2).to be_invalid
+        expect(contract_parking_space_2.errors[:parking_space]).to eq ["はすでに契約されています。"]
       end
 
       it 'parking_spaceが紐づいていない場合' do

--- a/spec/models/contract_parking_space_spec.rb
+++ b/spec/models/contract_parking_space_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe ContractParkingSpace, type: :model do
       it '契約終了日が契約開始日よりも前だった場合' do
         contract_parking_space = build(:contract_parking_space, start_date: Date.today, end_date: Date.yesterday)
         expect(contract_parking_space).to be_invalid
+        expect(contract_parking_space.errors[:end_date]).to eq ["は契約開始日より前ですので設定できません。"]
       end
 
       it 'contractorが紐づいていない場合' do

--- a/spec/models/contract_parking_space_spec.rb
+++ b/spec/models/contract_parking_space_spec.rb
@@ -77,7 +77,9 @@ RSpec.describe ContractParkingSpace, type: :model do
         it 'start_dateを変更した場合' do
           contract_parking_space = create(:contract_parking_space, start_date: 1.month.ago.to_date)
           contract_parking_space.start_date = Date.today
+
           expect(contract_parking_space).to be_invalid
+          expect(contract_parking_space.errors[:start_date]).to eq ["契約が有効のため変更できません。"]
         end
 
         it '契約終了が契約開始日よりも後の場合' do

--- a/test/factories/contract_parking_spaces.rb
+++ b/test/factories/contract_parking_spaces.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :contract_parking_space do
     start_date { Date.today }
     end_date { 1.month.from_now }
+    end_date_undetermined { false }
     association :parking_manager
     association :parking_space
     association :contractor

--- a/test/factories/contract_parking_spaces.rb
+++ b/test/factories/contract_parking_spaces.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :contract_parking_space do
-    start_date { Date.today }
+    start_date { 1.month.ago }
     end_date { 1.month.from_now }
     end_date_undetermined { false }
     association :parking_manager

--- a/test/factories/contractors.rb
+++ b/test/factories/contractors.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :contractor do
-    first_name { Faker::Name.first_name }
-    last_name { Faker::Name.last_name }
+    first_name { Faker::Name.last_name }
+    last_name { Faker::Name.first_name }
     prefecture { I18n.t("prefectures").values.sample }
     city { Faker::Address.city }
     street_address { Faker::Address.street_address }

--- a/test/factories/parking_managers.rb
+++ b/test/factories/parking_managers.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :parking_manager do
-    first_name { Faker::Name.first_name }
-    last_name { Faker::Name.last_name }
+    first_name { Faker::Name.last_name }
+    last_name { Faker::Name.first_name }
     email { Faker::Internet.email }
     password { Faker::Internet.password }
     prefecture { I18n.t("prefectures").values.sample }


### PR DESCRIPTION
# 概要
contract_parking_spaceのバリデーションの追加に基づき仕様変更

# 内容
テストコードの実装により抜けていたバリデーションとテストを追加しました。
実装にあたり新しいカラムの追加とカラムのメタデータの変更を行いました。
FactoryBot.contract_parking_spaceの設定を変更

## 新しいカラム
- [ ] contract_parking_space
- end_date_undetermined：契約終了日が未設定の場合true、終了日が決まっている場合 false

## カラムの変更
 - [ ] contract_parking_space
 - start_date：デフォルトの'1999-01-01' を削除

## 追加したバリデーション
- [ ] create
 - end_dateがstart_dateより前になった時
 - すでにparking_spaceが契約していた時

- [ ] update
- start_dateを変更しようとした時
- 契約者を変更しようとした時
- 駐車場を変更しようとした時

## 追加したテスト
### バリデーション:　成功
- [ ] create
- end_date_undeterminedがtrue、且つend_dateがnilの場合のテスト
- 